### PR TITLE
Replace manual default RatingConstants implementation with a trait implementation

### DIFF
--- a/src/model/constants.rs
+++ b/src/model/constants.rs
@@ -11,20 +11,22 @@ pub struct RatingConstants {
     pub volatility_growth_rate: f64
 }
 
-pub fn default_constants() -> RatingConstants {
-    let multiplier = 45;
-    let sigma = (25.0 / 5.0) * multiplier as f64;
+impl Default for RatingConstants {
+    fn default() -> Self {
+        let multiplier = 45;
+        let sigma = (25.0 / 5.0) * multiplier as f64;
 
-    RatingConstants {
-        multiplier,
-        default_mu: 15.0 * multiplier as f64,
-        default_sigma: sigma,
-        default_tau: sigma / 100.0,
-        default_beta: sigma / 2.0,
-        default_kappa: 0.0001,
-        decay_minimum: 825.0,
-        decay_days: 115,
-        decay_rate: 0.06 * multiplier as f64,
-        volatility_growth_rate: 0.08 * (i32::pow(multiplier, 2) as f64),
+        Self {
+            multiplier,
+            default_mu: 15.0 * multiplier as f64,
+            default_sigma: sigma,
+            default_tau: sigma / 100.0,
+            default_beta: sigma / 2.0,
+            default_kappa: 0.0001,
+            decay_minimum: 825.0,
+            decay_days: 115,
+            decay_rate: 0.06 * multiplier as f64,
+            volatility_growth_rate: 0.08 * (i32::pow(multiplier, 2) as f64),
+        }
     }
 }

--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use chrono::{DateTime, FixedOffset};
 use crate::api::api_structs::RatingAdjustment;
-use crate::model::constants::default_constants;
+use crate::model::constants::RatingConstants;
 
 /// Tracks decay activity for players
 pub struct DecayTracker {
@@ -79,7 +79,7 @@ impl DecayTracker {
     /// - d: The current time (in this context, it is the time the match was played)
     /// - t: The last time the user played
     fn n_decay(d: DateTime<FixedOffset>, t: DateTime<FixedOffset>) -> i64 {
-        let constants = default_constants();
+        let constants = RatingConstants::default();
         let decay_days = constants.decay_days;
 
         let duration = d.signed_duration_since(t);
@@ -95,20 +95,20 @@ impl DecayTracker {
 }
 
 pub fn is_decay_possible(mu: f64) -> bool {
-    let constants = default_constants();
+    let constants = RatingConstants::default();
 
     mu > constants.decay_minimum
 }
 
 pub fn decay_sigma(sigma: f64) -> f64 {
-    let constants = default_constants();
+    let constants = RatingConstants::default();
     let new_sigma = (sigma.powi(2) + constants.volatility_growth_rate).sqrt();
 
     return new_sigma.min(constants.default_sigma);
 }
 
 pub fn decay_mu(mu: f64) -> f64 {
-    let constants = default_constants();
+    let constants = RatingConstants::default();
     let new_mu = mu - constants.decay_rate;
 
     return new_mu.max(constants.decay_minimum);
@@ -119,13 +119,13 @@ pub fn decay_mu(mu: f64) -> f64 {
 mod tests {
     use std::ops::Add;
     use chrono::{DateTime};
-    use crate::model::constants::default_constants;
+    use crate::model::constants::RatingConstants;
     use crate::model::decay::{decay_mu, decay_sigma, DecayTracker, is_decay_possible};
 
     #[test]
     fn test_decay() {
         let id = 1;
-        let constants = default_constants();
+        let constants = RatingConstants::default();
         let mu = 1000.0;
         let sigma = 200.0;
 
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_n_decay() {
-        let days = default_constants().decay_days;
+        let days = RatingConstants::default().decay_days;
 
         let t = DateTime::parse_from_rfc3339("2021-01-01T00:00:00+00:00").unwrap().fixed_offset();
         let d = t.add(chrono::Duration::days(days));
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_n_decay_less_than_decay_days() {
-        let days = default_constants().decay_days - 1;
+        let days = RatingConstants::default().decay_days - 1;
 
         let t = DateTime::parse_from_rfc3339("2021-01-01T00:00:00+00:00").unwrap().fixed_offset();
         let d = t.add(chrono::Duration::days(days));
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn test_decay_possible() {
         let mu = 500.0;
-        let decay_min = default_constants().decay_minimum;
+        let decay_min = RatingConstants::default().decay_minimum;
 
         let decay_possible = mu > (decay_min);
 
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_decay_sigma_standard() {
-        let constants = default_constants();
+        let constants = RatingConstants::default();
 
         let sigma = 200.1;
         let new_sigma = decay_sigma(sigma);
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_decay_sigma_maximum_default() {
-        let constants = default_constants();
+        let constants = RatingConstants::default();
 
         let sigma = 999.0;
         let new_sigma = decay_sigma(sigma);
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_decay_mu_standard() {
-        let constants = default_constants();
+        let constants = RatingConstants::default();
 
         let mu = 1100.0;
         let new_mu = decay_mu(mu);
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_decay_mu_min_decay() {
-        let constants = default_constants();
+        let constants = RatingConstants::default();
 
         let mu = 825.0;
         let new_mu = decay_mu(mu);

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use openskill::model::plackett_luce::PlackettLuce;
 use openskill::rating::{default_gamma, Rating};
 use crate::api::api_structs::{Match, MatchRatingStats, Player, RatingAdjustment};
-use crate::model::constants::default_constants;
+use crate::model::constants::RatingConstants;
 use crate::model::structures::match_cost::MatchCost;
 use crate::model::structures::mode::Mode;
 use crate::model::structures::player_rating::PlayerRating;
@@ -13,7 +13,7 @@ use crate::model::structures::rating_calculation_result::RatingCalculationResult
 use crate::utils::progress_utils::progress_bar;
 
 pub fn create_model() -> PlackettLuce {
-    let constants = default_constants();
+    let constants = RatingConstants::default();
     PlackettLuce::new(constants.default_beta,
                       constants.default_kappa,
                       default_gamma)
@@ -23,7 +23,7 @@ pub fn create_model() -> PlackettLuce {
 
 pub fn create_initial_ratings(matches: Vec<Match>, players: Vec<Player>) -> Vec<PlayerRating> {
     // The first step in the rating algorithm. Generate ratings from known ranks.
-    let constants = default_constants();
+    let constants = RatingConstants::default();
 
     // A fast lookup used for understanding who has default ratings created at this time.
     let mut stored_lookup_log: HashSet<(i32, i32)> = HashSet::new();
@@ -212,7 +212,7 @@ pub fn match_costs(m: &Match) -> Option<Vec<MatchCost>> {
 }
 
 pub fn mu_for_rank(rank: i32) -> f64 {
-    let constants = default_constants();
+    let constants = RatingConstants::default();
     let multiplier = constants.multiplier as f64;
     let val = multiplier * (45.0 - (3.2 * (rank as f64).ln()));
 


### PR DESCRIPTION
Replaces `default_constants()` with a manual implementation of `Default`

A low hanging fruit but that's the standard way to do this generally, and there doesn't seem to be a reason to do otherwise