### PR TITLE
Allow dead code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 chrono = {  version = "0.4.33", features = ["serde"] }
 openskill = "0.0.1"
 statrs = "0.16.0"
+
+[lints.rust]
+dead_code = "allow"
+unused_variables = "allow"


### PR DESCRIPTION
Since we still prototyping my suggestion is temporarily allow dead code so warning about unused code doesn't flood your terminal during development.