### PR TITLE
Fix decay adjustments

### DIFF
--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -63,23 +63,27 @@ impl DecayTracker {
         }
 
         let mut adjustments = Vec::new();
+        let mut old_mu;
+        let mut old_sigma;
         let mut new_mu = mu;
         let mut new_sigma = sigma;
 
         for i in 0..decay_weeks {
             // Increment time by 7 days for each decay application (this is for accurate timestamps)
             let now = last_play_time.unwrap().fixed_offset() + chrono::Duration::days(i * 7);
+            old_mu = new_mu;
+            old_sigma = new_sigma;
             new_mu = decay_mu(new_mu);
             new_sigma = decay_sigma(new_sigma);
-
+            
             let adjustment = RatingAdjustment {
                 player_id,
                 mode,
-                rating_adjustment_amount: new_mu - mu,
-                volatility_adjustment_amount: new_sigma - sigma,
-                rating_before: mu,
+                rating_adjustment_amount: new_mu - old_mu,
+                volatility_adjustment_amount: new_sigma - old_sigma,
+                rating_before: old_mu,
                 rating_after: new_mu,
-                volatility_before: sigma,
+                volatility_before: old_sigma,
                 volatility_after: new_sigma,
                 rating_adjustment_type: 0,
                 timestamp: now

--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -75,7 +75,7 @@ impl DecayTracker {
             old_sigma = new_sigma;
             new_mu = decay_mu(new_mu);
             new_sigma = decay_sigma(new_sigma);
-            
+
             let adjustment = RatingAdjustment {
                 player_id,
                 mode,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -634,15 +634,6 @@ pub fn calculate_processed_match_data(
     }
     bar.finish();
 
-    for i in matches_stats.iter() {
-        for j in &i.players_stats {
-            let (id, mode, mu, sigma) = (j.player_id, i.mode, j.new_rating.mu, j.new_rating.sigma);
-            if let Some(mut decay_list) = decay_tracker.decay(id, mode, mu, sigma, Utc::now().fixed_offset()) {
-                decays.append(&mut decay_list)
-            }
-        }
-    }
-
     (matches_stats, decays)
 }
 


### PR DESCRIPTION
1. Fixes adjustments being pushed WAY more than they should've, causing an insane waste of memory (blame me)
2. Fixes the incorrect reusing of `mu` in `decay`, which led to incorrect mu deltas in `RatingAdjustment`structs