### PR TITLE
Fix country ranking bugs

### DIFF
--- a/benches/calc_rating.rs
+++ b/benches/calc_rating.rs
@@ -44,7 +44,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     for id in player_ids {
         initial_ratings.push(PlayerRating {
             player_id: id,
-            mode: Ruleset::Osu,
+            ruleset: Ruleset::Osu,
             rating: Rating {
                 mu: 1500.0 + offset,
                 sigma: 200.0

--- a/benches/global_country_rank.rs
+++ b/benches/global_country_rank.rs
@@ -56,7 +56,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         for _ in 0..AMOUNT_OF_USERS_IN_ONE_COUNTRY {
             ratings.push(PlayerRating {
                 player_id: rng.gen_range(0..100_000), // Random player id
-                mode: Ruleset::Osu,
+                ruleset: Ruleset::Osu,
                 rating: Rating {
                     mu: rng.gen_range(0.0..2000.0),
                     sigma: 200.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ async fn get_all_matches() -> Vec<Match> {
 
     let chunk_size = 250;
     let mut total = chunk_size;
-    for page in 1.. {
+    for page in 1..20 {
         let mut result = client.get_matches(page, chunk_size).await.unwrap();
         matches.append(&mut result.results);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ async fn get_all_matches() -> Vec<Match> {
 
     let chunk_size = 250;
     let mut total = chunk_size;
-    for page in 1..20 {
+    for page in 1.. {
         let mut result = client.get_matches(page, chunk_size).await.unwrap();
         matches.append(&mut result.results);
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -251,7 +251,7 @@ pub fn calculate_country_ranks(existing_ratings: &mut [PlayerRating], mode: Rule
         countries.insert(x);
     });
 
-    // Sort by gamemode, essentially grouping them. Useful for slicing
+    // Sort by ruleset, essentially grouping them. Useful for slicing
     existing_ratings.sort_by(|x, y| {
         if x.ruleset != mode {
             Ordering::Less
@@ -261,23 +261,23 @@ pub fn calculate_country_ranks(existing_ratings: &mut [PlayerRating], mode: Rule
     });
 
     // Finding gamemode slice
-    let gamemode_start = match existing_ratings.iter().position(|x| x.ruleset == mode) {
+    let ruleset_start = match existing_ratings.iter().position(|x| x.ruleset == mode) {
         Some(v) => v,
         None => return
     };
 
-    let gamemode_slice = &mut existing_ratings[gamemode_start..];
+    let ruleset_slice = &mut existing_ratings[ruleset_start..];
 
-    let gamemode_end = gamemode_slice
+    let ruleset_end = ruleset_slice
         .iter()
         .position(|x| x.ruleset != mode)
-        .unwrap_or(gamemode_slice.len());
+        .unwrap_or(ruleset_slice.len());
 
-    let gamemode_slice = &mut gamemode_slice[..gamemode_end];
+    let ruleset_slice = &mut ruleset_slice[..ruleset_end];
 
     for country in countries {
         // TODO
-        let country_start = gamemode_slice.iter().position(|x| x.country == country);
+        let country_start = ruleset_slice.iter().position(|x| x.country == country);
 
         if country_start.is_none() {
             continue;
@@ -285,7 +285,7 @@ pub fn calculate_country_ranks(existing_ratings: &mut [PlayerRating], mode: Rule
 
         let country_start = country_start.unwrap();
 
-        let country_slice = &mut gamemode_slice[country_start..];
+        let country_slice = &mut ruleset_slice[country_start..];
 
         let country_end = country_slice
             .iter()
@@ -2657,6 +2657,75 @@ mod tests {
         assert_eq!(players.iter().find(|x| x.player_id == 101).unwrap().global_ranking, 2);
 
         assert_eq!(players.iter().find(|x| x.player_id == 102).unwrap().global_ranking, 3);
+    }
+
+    #[test]
+    fn test_country_ranking() {
+        let mut players = vec![
+            PlayerRating {
+                player_id: 1,
+                ruleset: Ruleset::Osu,
+                rating: Rating {
+                    mu: 1500.0,
+                    sigma: 200.0
+                },
+                global_ranking: 0,
+                country_ranking: 0,
+                country: "RU".to_string()
+            },
+            PlayerRating {
+                player_id: 2,
+                ruleset: Ruleset::Osu,
+                rating: Rating {
+                    mu: 1499.0,
+                    sigma: 200.0
+                },
+                global_ranking: 0,
+                country_ranking: 0,
+                country: "RU".to_string()
+            },
+            PlayerRating {
+                player_id: 3,
+                ruleset: Ruleset::Osu,
+                rating: Rating {
+                    mu: 1498.0,
+                    sigma: 200.0
+                },
+                global_ranking: 0,
+                country_ranking: 0,
+                country: "RU".to_string()
+            },
+            PlayerRating {
+                player_id: 4,
+                ruleset: Ruleset::Osu,
+                rating: Rating {
+                    mu: 1505.0,
+                    sigma: 200.0
+                },
+                global_ranking: 0,
+                country_ranking: 0,
+                country: "US".to_string()
+            },
+            PlayerRating {
+                player_id: 5,
+                ruleset: Ruleset::Osu,
+                rating: Rating {
+                    mu: 1504.0,
+                    sigma: 200.0
+                },
+                global_ranking: 0,
+                country_ranking: 0,
+                country: "US".to_string()
+            },
+        ];
+
+        calculate_country_ranks(&mut players, Ruleset::Osu);
+
+        assert_eq!(players.iter().find(|x| x.player_id == 1).unwrap().country_ranking, 1);
+        assert_eq!(players.iter().find(|x| x.player_id == 2).unwrap().country_ranking, 2);
+        assert_eq!(players.iter().find(|x| x.player_id == 3).unwrap().country_ranking, 3);
+        assert_eq!(players.iter().find(|x| x.player_id == 4).unwrap().country_ranking, 1);
+        assert_eq!(players.iter().find(|x| x.player_id == 5).unwrap().country_ranking, 2);
     }
 
     #[test]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -276,7 +276,6 @@ pub fn calculate_country_ranks(existing_ratings: &mut [PlayerRating], mode: Rule
     let ruleset_slice = &mut ruleset_slice[..ruleset_end];
 
     for country in countries {
-        // TODO
         let country_start = ruleset_slice.iter().position(|x| x.country == country);
 
         if country_start.is_none() {
@@ -284,7 +283,6 @@ pub fn calculate_country_ranks(existing_ratings: &mut [PlayerRating], mode: Rule
         }
 
         let country_start = country_start.unwrap();
-
         let country_slice = &mut ruleset_slice[country_start..];
 
         let country_end = country_slice
@@ -2661,71 +2659,49 @@ mod tests {
 
     #[test]
     fn test_country_ranking() {
-        let mut players = vec![
-            PlayerRating {
-                player_id: 1,
+        let mut players = vec![];
+
+        // 50 RU players, 10 US players. Rank begins at 1500 and increases by 1.
+        for i in 0..50 {
+            players.push(PlayerRating {
+                player_id: i,
                 ruleset: Ruleset::Osu,
                 rating: Rating {
-                    mu: 1500.0,
+                    mu: 1500.0 + i as f64,
                     sigma: 200.0
                 },
                 global_ranking: 0,
                 country_ranking: 0,
                 country: "RU".to_string()
-            },
-            PlayerRating {
-                player_id: 2,
+            });
+        }
+
+        for i in 50..60 {
+            players.push(PlayerRating {
+                player_id: i,
                 ruleset: Ruleset::Osu,
                 rating: Rating {
-                    mu: 1499.0,
-                    sigma: 200.0
-                },
-                global_ranking: 0,
-                country_ranking: 0,
-                country: "RU".to_string()
-            },
-            PlayerRating {
-                player_id: 3,
-                ruleset: Ruleset::Osu,
-                rating: Rating {
-                    mu: 1498.0,
-                    sigma: 200.0
-                },
-                global_ranking: 0,
-                country_ranking: 0,
-                country: "RU".to_string()
-            },
-            PlayerRating {
-                player_id: 4,
-                ruleset: Ruleset::Osu,
-                rating: Rating {
-                    mu: 1505.0,
+                    mu: 1500.0 + i as f64,
                     sigma: 200.0
                 },
                 global_ranking: 0,
                 country_ranking: 0,
                 country: "US".to_string()
-            },
-            PlayerRating {
-                player_id: 5,
-                ruleset: Ruleset::Osu,
-                rating: Rating {
-                    mu: 1504.0,
-                    sigma: 200.0
-                },
-                global_ranking: 0,
-                country_ranking: 0,
-                country: "US".to_string()
-            },
-        ];
+            });
+        }
 
         calculate_country_ranks(&mut players, Ruleset::Osu);
 
-        assert_eq!(players.iter().find(|x| x.player_id == 1).unwrap().country_ranking, 1);
-        assert_eq!(players.iter().find(|x| x.player_id == 2).unwrap().country_ranking, 2);
-        assert_eq!(players.iter().find(|x| x.player_id == 3).unwrap().country_ranking, 3);
-        assert_eq!(players.iter().find(|x| x.player_id == 4).unwrap().country_ranking, 1);
-        assert_eq!(players.iter().find(|x| x.player_id == 5).unwrap().country_ranking, 2);
+        // Ensure that the RU players are ranked 50-1
+        // and the US players are ranked 10-1
+
+        for i in 0..50 {
+            assert_eq!(players.iter().find(|x| x.player_id == i).unwrap().country_ranking, 50 - i as u32);
+        }
+
+        for i in 50..60 {
+            assert_eq!(players.iter().find(|x| x.player_id == i).unwrap().country_ranking, 10 - (i - 50) as u32);
+        }
     }
 
     #[test]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,9 @@
-use std::{cmp::Ordering, collections::{HashMap, HashSet}, iter::Sum, thread};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    iter::Sum,
+    thread
+};
 
 use chrono::Utc;
 use itertools::Itertools;
@@ -2694,11 +2699,17 @@ mod tests {
         // and the US players are ranked 10-1
 
         for i in 0..50 {
-            assert_eq!(players.iter().find(|x| x.player_id == i).unwrap().country_ranking, 50 - i as u32);
+            assert_eq!(
+                players.iter().find(|x| x.player_id == i).unwrap().country_ranking,
+                50 - i as u32
+            );
         }
 
         for i in 50..60 {
-            assert_eq!(players.iter().find(|x| x.player_id == i).unwrap().country_ranking, 10 - (i - 50) as u32);
+            assert_eq!(
+                players.iter().find(|x| x.player_id == i).unwrap().country_ranking,
+                10 - (i - 50) as u32
+            );
         }
     }
 

--- a/src/model/structures/player_rating.rs
+++ b/src/model/structures/player_rating.rs
@@ -4,7 +4,7 @@ use openskill::rating::Rating;
 #[derive(Debug, Clone)]
 pub struct PlayerRating {
     pub player_id: i32,
-    pub mode: Ruleset,
+    pub ruleset: Ruleset,
     pub rating: Rating,
     pub global_ranking: u32,
     pub country_ranking: u32,


### PR DESCRIPTION
Fixes a bug with the country ranking algorithm. The ratings collection was not sorted by country, causing this code to basically fail immediately as it is looking for the next item in the list that does not match the current country:

```rs
let country_end = country_slice_begin
            .iter()
            .position(|x| x.country != country)
            .unwrap_or(country_slice_begin.len());
```

Fix was to apply the following before iterating through each country:

```rs
ruleset_slice.sort_by(|x, y| x.country.partial_cmp(&y.country).unwrap());
```

Closes #53 