### PR TITLE
Change all statics into consts

### DIFF
--- a/src/model/constants.rs
+++ b/src/model/constants.rs
@@ -1,24 +1,23 @@
 // Model constants
-pub static MULTIPLIER: f64 = 45.0;
-pub static SIGMA: f64 = 5.0 * MULTIPLIER;
-pub static MU: f64 = 15.0 * MULTIPLIER;
-pub static TAU: f64 = SIGMA / 100.0;
-pub static BETA: f64 = SIGMA / 2.0;
-pub static KAPPA: f64 = 0.0001;
-pub static DECAY_DAYS: u64 = 115;
-pub static DECAY_MINIMUM: f64 = 18.0 * MULTIPLIER;
-pub static DECAY_RATE: f64 = 0.06 * MULTIPLIER;
-pub static ABSOLUTE_RATING_FLOOR: f64 = 100.0;
+pub const MULTIPLIER: f64 = 45.0;
+pub const SIGMA: f64 = 5.0 * MULTIPLIER;
+pub const MU: f64 = 15.0 * MULTIPLIER;
+pub const TAU: f64 = SIGMA / 100.0;
+pub const BETA: f64 = SIGMA / 2.0;
+pub const KAPPA: f64 = 0.0001;
+pub const DECAY_DAYS: u64 = 115;
+pub const DECAY_MINIMUM: f64 = 18.0 * MULTIPLIER;
+pub const DECAY_RATE: f64 = 0.06 * MULTIPLIER;
+pub const ABSOLUTE_RATING_FLOOR: f64 = 100.0;
 // Default rating constants for osu!
-pub static OSU_RATING_FLOOR: f64 = 5.0;
-pub static OSU_RATING_CEILING: f64 = 30.0;
-pub static OSU_RATING_INTERCEPT: f64 = 45.0;
-pub static OSU_RATING_SLOPE: f64 = 3.2;
+pub const OSU_RATING_FLOOR: f64 = 5.0;
+pub const OSU_RATING_CEILING: f64 = 30.0;
+pub const OSU_RATING_INTERCEPT: f64 = 45.0;
+pub const OSU_RATING_SLOPE: f64 = 3.2;
+
+pub const VOLATILITY_GROWTH_RATE: f64 = 0.08 * (MULTIPLIER * MULTIPLIER);
 
 // Computed constants
-lazy_static! {
-    pub static ref VOLATILITY_GROWTH_RATE: f64 = 0.08 * (f64::powf(MULTIPLIER, 2.0));
-}
 
 pub const BLUE_TEAM_ID: i32 = 1;
 pub const RED_TEAM_ID: i32 = 2;

--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -120,7 +120,7 @@ pub fn is_decay_possible(mu: f64) -> bool {
 }
 
 pub fn decay_sigma(sigma: f64) -> f64 {
-    let new_sigma = (sigma.powf(2.0) + *constants::VOLATILITY_GROWTH_RATE).sqrt();
+    let new_sigma = (sigma.powf(2.0) + constants::VOLATILITY_GROWTH_RATE).sqrt();
 
     new_sigma.min(constants::SIGMA)
 }
@@ -230,7 +230,7 @@ mod tests {
     fn test_decay_sigma_standard() {
         let sigma = 200.1;
         let new_sigma = decay_sigma(sigma);
-        let expected = (sigma.powf(2.0) + *constants::VOLATILITY_GROWTH_RATE).sqrt();
+        let expected = (sigma.powf(2.0) + constants::VOLATILITY_GROWTH_RATE).sqrt();
 
         assert_eq!(new_sigma, expected);
     }


### PR DESCRIPTION
Title.

Doesn't matter too much, but I noticed that inline const expressions got stabilised in 1.79 and decided to check on this. Apparently checking on this wasn't necessary because I don't think it changes the MSRV.