### PR TITLE
Remove unused calculate player adjustments function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate lazy_static;
 
 pub mod api;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     model::{
         constants::BLUE_TEAM_ID,
-        decay::{DecayTracker, is_decay_possible},
+        decay::{is_decay_possible, DecayTracker},
         structures::{
             match_cost::MatchCost,
             player_rating::PlayerRating,
@@ -1363,9 +1363,8 @@ mod tests {
     };
 
     use super::{
-        calculate_global_ranks, calculate_match_win_records,
-        calculate_processed_match_data, create_initial_ratings, create_match_win_record, create_model, game_win_record,
-        hash_country_mappings, player_match_stats
+        calculate_global_ranks, calculate_match_win_records, calculate_processed_match_data, create_initial_ratings,
+        create_match_win_record, create_model, game_win_record, hash_country_mappings, player_match_stats
     };
 
     fn match_from_json(json: &str) -> Match {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1652,21 +1652,21 @@ mod tests {
             let actual_country_rank_change = stat.country_rank_change;
             let actual_percentile_change = stat.percentile_change;
 
-            assert!((expected_starting_mu - actual_starting_mu).abs() < f64::EPSILON);
-            assert!((expected_starting_sigma - actual_starting_sigma).abs() < f64::EPSILON);
-            assert!((expected_after_mu - actual_after_mu).abs() < f64::EPSILON);
-            assert!((expected_after_sigma - actual_after_sigma).abs() < f64::EPSILON);
-            assert!((expected_mu_change - actual_mu_change).abs() < f64::EPSILON);
-            assert!((expected_sigma_change - actual_sigma_change).abs() < f64::EPSILON);
+            assert_eq!(expected_starting_mu.to_bits(), actual_starting_mu.to_bits());
+            assert_eq!(expected_starting_sigma.to_bits(), actual_starting_sigma.to_bits());
+            assert_eq!(expected_after_mu.to_bits(), actual_after_mu.to_bits());
+            assert_eq!(expected_after_sigma.to_bits(), actual_after_sigma.to_bits());
+            assert_eq!(expected_mu_change.to_bits(), actual_mu_change.to_bits());
+            assert_eq!(expected_sigma_change.to_bits(), actual_sigma_change.to_bits());
             assert_eq!(expected_global_rank_before, actual_global_rank_before);
             assert_eq!(expected_country_rank_before, actual_country_rank_before);
-            assert!((expected_percentile_before - actual_percentile_before).abs() < f64::EPSILON);
+            assert_eq!(expected_percentile_before.to_bits(), actual_percentile_before.to_bits());
             assert_eq!(expected_global_rank_after, actual_global_rank_after);
             assert_eq!(expected_country_rank_after, actual_country_rank_after);
-            assert!((expected_percentile_after - actual_percentile_after).abs() < f64::EPSILON);
+            assert_eq!(expected_percentile_after.to_bits(), actual_percentile_after.to_bits());
             assert_eq!(expected_global_rank_change, actual_global_rank_change);
             assert_eq!(expected_country_rank_change, actual_country_rank_change);
-            assert!((expected_percentile_change - actual_percentile_change).abs() < f64::EPSILON);
+            assert_eq!(expected_percentile_change.to_bits(), actual_percentile_change.to_bits());
         }
     }
 


### PR DESCRIPTION
- Removes unused function `calculate_player_adjustments` (the function also does not do what adjustments are designed for)
- Clippy