### PR TITLE
Algorithm changes, database updates

### DIFF
--- a/src/database/db.rs
+++ b/src/database/db.rs
@@ -401,7 +401,7 @@ impl DbClient {
 
     async fn truncate_player_ratings(&self) {
         self.client
-            .execute("TRUNCATE TABLE player_ratings CASCADE", &[])
+            .execute("TRUNCATE TABLE player_ratings RESTART IDENTITY CASCADE", &[])
             .await
             .unwrap();
         println!("Truncated player_ratings table!");
@@ -425,7 +425,7 @@ impl DbClient {
 
     async fn truncate_rating_adjustments(&self) {
         self.client
-            .execute("TRUNCATE TABLE rating_adjustments CASCADE", &[])
+            .execute("TRUNCATE TABLE rating_adjustments RESTART IDENTITY CASCADE", &[])
             .await
             .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,9 @@ async fn main() {
     client.save_results(&results).await;
 
     // 8. Update all match processing statuses
-    client.set_match_processing_status_done(&matches).await
+    client.set_match_processing_status_done(&matches).await;
+
+    println!("Processing complete");
 }
 
 async fn client() -> DbClient {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,26 +9,29 @@ use std::{collections::HashMap, env};
 async fn main() {
     let client: DbClient = client().await;
 
-    // 1. Fetch matches and players for processing
+    // 1. Rollback processing statuses of matches & tournaments
+    client.rollback_processing_statuses().await;
+
+    // 2. Fetch matches and players for processing
     let matches = client.get_matches().await;
     let players = client.get_players().await;
 
-    // 2. Generate initial ratings
+    // 3. Generate initial ratings
     let initial_ratings = initial_ratings(&players);
 
-    // 3. Generate country mapping and set
+    // 4. Generate country mapping and set
     let country_mapping: HashMap<i32, String> = generate_country_mapping_players(&players);
 
-    // 4. Create the model
+    // 5. Create the model
     let mut model = OtrModel::new(&initial_ratings, &country_mapping);
 
-    // 5. Process matches
+    // 6. Process matches
     let results = model.process(&matches);
 
-    // 6. Save results in database
+    // 7. Save results in database
     client.save_results(&results).await;
 
-    // 7. Update all match processing statuses
+    // 8. Update all match processing statuses
     client.set_match_processing_status_done(&matches).await
 }
 

--- a/src/model/constants.rs
+++ b/src/model/constants.rs
@@ -1,6 +1,6 @@
 // Model constants
-pub const MULTIPLIER: f64 = 66.67;
-pub const DEFAULT_VOLATILITY: f64 = 6.0 * MULTIPLIER;
+pub const MULTIPLIER: f64 = 60.0;
+pub const DEFAULT_VOLATILITY: f64 = 5.0 * MULTIPLIER;
 pub const DEFAULT_RATING: f64 = 15.0 * MULTIPLIER;
 pub const TAU: f64 = DEFAULT_VOLATILITY / 100.0;
 pub const BETA: f64 = DEFAULT_VOLATILITY / 2.0;

--- a/src/model/constants.rs
+++ b/src/model/constants.rs
@@ -1,6 +1,6 @@
 // Model constants
-pub const MULTIPLIER: f64 = 60.0;
-pub const DEFAULT_VOLATILITY: f64 = 5.0 * MULTIPLIER;
+pub const MULTIPLIER: f64 = 66.67;
+pub const DEFAULT_VOLATILITY: f64 = 6.0 * MULTIPLIER;
 pub const DEFAULT_RATING: f64 = 15.0 * MULTIPLIER;
 pub const TAU: f64 = DEFAULT_VOLATILITY / 100.0;
 pub const BETA: f64 = DEFAULT_VOLATILITY / 2.0;

--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -2,7 +2,7 @@ use crate::{
     database::db_structs::{PlayerRating, RatingAdjustment},
     model::{
         constants,
-        constants::{DECAY_DAYS, MULTIPLIER},
+        constants::DECAY_DAYS,
         rating_tracker::RatingTracker,
         structures::{
             rating_adjustment_type::RatingAdjustmentType::{Decay, Initial},

--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -158,7 +158,7 @@ fn decay_rating(mu: f64, decay_floor: f64) -> f64 {
 
 /// The minimum possible decay value based on a player's peak rating
 fn decay_floor(peak_rating: f64) -> f64 {
-    DECAY_MINIMUM.max(0.5 * (constants::DECAY_MINIMUM + peak_rating))
+    DECAY_MINIMUM.max(0.5 * (DECAY_MINIMUM + peak_rating))
 }
 
 fn peak_rating(player_rating: &PlayerRating) -> Option<&RatingAdjustment> {
@@ -321,10 +321,10 @@ mod tests {
 
     #[test]
     fn test_decay_floor() {
-        let mu = 1000.0;
-        let floor = decay_floor(mu);
+        let peak_rating = 5000.0;
+        let floor = decay_floor(peak_rating);
 
-        assert_abs_diff_eq!(floor, 950.0)
+        assert_abs_diff_eq!(floor, DECAY_MINIMUM.max(0.5 * (DECAY_MINIMUM + peak_rating)))
     }
 
     #[test]
@@ -332,6 +332,7 @@ mod tests {
         let mu = 500.0;
         let floor = decay_floor(mu);
 
-        assert_abs_diff_eq!(floor, 900.0)
+        assert_abs_diff_eq!(floor, 15.0 * MULTIPLIER);
+        assert!(mu < floor);
     }
 }

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -23,7 +23,9 @@ pub struct OtrModel {
 }
 
 impl OtrModel {
-    fn default_gamma_2(_: f64, k: f64, _: &TeamRating) -> f64 {
+    /// Custom gamma function, passed into the PlackettLuce model.
+    /// This controls how quickly volatility decreases over time.
+    fn gamma_override(_: f64, k: f64, _: &TeamRating) -> f64 {
         0.5 / k
     }
 
@@ -36,7 +38,7 @@ impl OtrModel {
         OtrModel {
             rating_tracker: tracker,
             decay_tracker: DecayTracker,
-            model: PlackettLuce::new(DEFAULT_BETA, KAPPA, Self::default_gamma_2)
+            model: PlackettLuce::new(DEFAULT_BETA, KAPPA, Self::gamma_override)
         }
     }
 

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -25,7 +25,7 @@ pub struct OtrModel {
 
 impl OtrModel {
     fn default_gamma_2(c: f64, k: f64, team: &TeamRating) -> f64 {
-        1.0 / k
+        0.5 / k
     }
 
     pub fn new(initial_player_ratings: &[PlayerRating], country_mapping: &HashMap<i32, String>) -> OtrModel {

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -15,6 +15,7 @@ use openskill::{
     rating::{default_gamma, Rating}
 };
 use std::collections::HashMap;
+use openskill::rating::TeamRating;
 
 pub struct OtrModel {
     pub model: PlackettLuce,
@@ -23,6 +24,10 @@ pub struct OtrModel {
 }
 
 impl OtrModel {
+    fn default_gamma_2(c: f64, k: f64, team: &TeamRating) -> f64 {
+        1.0 / k
+    }
+
     pub fn new(initial_player_ratings: &[PlayerRating], country_mapping: &HashMap<i32, String>) -> OtrModel {
         let mut tracker = RatingTracker::new();
 
@@ -32,7 +37,7 @@ impl OtrModel {
         OtrModel {
             rating_tracker: tracker,
             decay_tracker: DecayTracker,
-            model: PlackettLuce::new(DEFAULT_BETA, KAPPA, default_gamma)
+            model: PlackettLuce::new(DEFAULT_BETA, KAPPA, Self::default_gamma_2)
         }
     }
 

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -26,7 +26,7 @@ impl OtrModel {
     /// Custom gamma function, passed into the PlackettLuce model.
     /// This controls how quickly volatility decreases over time.
     fn gamma_override(_: f64, k: f64, _: &TeamRating) -> f64 {
-        0.5 / k
+        1.0 / k
     }
 
     pub fn new(initial_player_ratings: &[PlayerRating], country_mapping: &HashMap<i32, String>) -> OtrModel {

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -12,10 +12,9 @@ use itertools::Itertools;
 use openskill::{
     constant::*,
     model::{model::Model, plackett_luce::PlackettLuce},
-    rating::{default_gamma, Rating}
+    rating::{Rating, TeamRating}
 };
 use std::collections::HashMap;
-use openskill::rating::TeamRating;
 
 pub struct OtrModel {
     pub model: PlackettLuce,
@@ -24,7 +23,7 @@ pub struct OtrModel {
 }
 
 impl OtrModel {
-    fn default_gamma_2(c: f64, k: f64, team: &TeamRating) -> f64 {
+    fn default_gamma_2(_: f64, k: f64, _: &TeamRating) -> f64 {
         0.5 / k
     }
 


### PR DESCRIPTION
# Algorithm Changes

The following changes were made to the algorithm to aid in achieving our desired rating numbers (a max around ~3,000).

- New multiplier constant: 66.67 (was `60.0`)
- New gamma function: `0.5 / k`
- New default volatility: `6 * multiplier` (was `5 * multiplier`)

# Database Changes

These changes are required to ensure that:

1. The data fetched from the database is actually ready for processing. The prior implementation was fetching verified data that was not yet ready for processing, leading to bugs in the results and a faulty state of data.
2. Before processing, match and tournament data which has a processing status of "Done" needs to be marked as "Needs processor data" (for tournaments this is "needs statistics processing"). We effectively return these items to an "in-progress" state so that they are included in the rating calculation. Without this step, matches which appeared in previous runs would not be included in future runs.