### PR TITLE
Use `ABSOLUTE_RATING_FLOOR`, `DEFAULT_VOLATILITY` as limits for `rating` and `volatility`

### DIFF
--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -1,7 +1,7 @@
 use crate::{
     database::db_structs::{Game, GameScore, Match, PlayerRating, RatingAdjustment},
     model::{
-        constants::{WEIGHT_A, WEIGHT_B},
+        constants::{ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY, WEIGHT_A, WEIGHT_B},
         decay::DecayTracker,
         rating_tracker::RatingTracker,
         structures::rating_adjustment_type::RatingAdjustmentType
@@ -15,7 +15,6 @@ use openskill::{
     rating::{Rating, TeamRating}
 };
 use std::collections::HashMap;
-use crate::model::constants::{ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY};
 
 pub struct OtrModel {
     pub model: PlackettLuce,
@@ -361,11 +360,14 @@ mod tests {
     pub use crate::utils::test_utils::*;
     use crate::{
         database::db_structs::PlayerRating,
-        model::{otr_model::OtrModel, structures::ruleset::Ruleset::Osu}
+        model::{
+            constants::{ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY},
+            otr_model::OtrModel,
+            structures::ruleset::Ruleset::Osu
+        }
     };
     use approx::assert_abs_diff_eq;
     use chrono::Utc;
-    use crate::model::constants::{ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY};
 
     #[test]
     fn test_rate() {

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -500,7 +500,7 @@ mod tests {
             generate_player_rating(1, Osu, ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY * 10.0, 1),
             generate_player_rating(2, Osu, ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY * 10.0, 1),
             generate_player_rating(3, Osu, ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY * 10.0, 1),
-            generate_player_rating(4, Osu, ABSOLUTE_RATING_FLOOR + 1.0, DEFAULT_VOLATILITY * 10.0, 1),
+            generate_player_rating(4, Osu, ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY * 10.0, 1),
         ];
 
         let countries = generate_country_mapping_player_ratings(player_ratings.as_slice(), "US");

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -497,10 +497,10 @@ mod tests {
     #[test]
     fn test_minimum_rating_maximum_volatility() {
         let player_ratings = vec![
-            generate_player_rating(1, Osu, 100.1, 500.0, 1),
-            generate_player_rating(2, Osu, 100.0, 500.0, 1),
-            generate_player_rating(3, Osu, 100.0, 500.0, 1),
-            generate_player_rating(4, Osu, 100.0, 500.0, 1),
+            generate_player_rating(1, Osu, ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY * 10.0, 1),
+            generate_player_rating(2, Osu, ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY * 10.0, 1),
+            generate_player_rating(3, Osu, ABSOLUTE_RATING_FLOOR, DEFAULT_VOLATILITY * 10.0, 1),
+            generate_player_rating(4, Osu, ABSOLUTE_RATING_FLOOR + 1.0, DEFAULT_VOLATILITY * 10.0, 1),
         ];
 
         let countries = generate_country_mapping_player_ratings(player_ratings.as_slice(), "US");


### PR DESCRIPTION
- Rating can no longer fall below the defined minimum.
- Volatility can no longer exceed the default.

Added tests for these.

Closes #81 