### PR TITLE
Store ruleset in `RatingAdjustment` and publish to database

### DIFF
--- a/src/database/db.rs
+++ b/src/database/db.rs
@@ -122,7 +122,7 @@ impl DbClient {
         let id_result = self.client.query(tournament_id_sql, &[]).await;
 
         if id_result.is_ok() {
-            for (_, row) in id_result.unwrap().iter().enumerate() {
+            for row in id_result.unwrap().iter() {
                 tournament_update_sql.push(format!(
                     "UPDATE tournaments SET processing_status = 4 \
                 WHERE id = {};\n",
@@ -341,7 +341,7 @@ impl DbClient {
             .to_string();
         let mut value_placeholders: Vec<String> = Vec::new();
 
-        for (_, rating) in player_ratings.iter().enumerate() {
+        for rating in player_ratings.iter() {
             // Directly embed the values into the query string
             value_placeholders.push(format!(
                 "({}, {}, {}, {}, {}, {}, {})",

--- a/src/database/db.rs
+++ b/src/database/db.rs
@@ -284,7 +284,7 @@ impl DbClient {
     /// Save all rating adjustments in a single batch query
     async fn save_rating_adjustments(&self, adjustment_mapping: &HashMap<i32, Vec<RatingAdjustment>>) {
         // Prepare the base query
-        let base_query = "INSERT INTO rating_adjustments (player_id, player_rating_id, match_id, \
+        let base_query = "INSERT INTO rating_adjustments (player_id, ruleset, player_rating_id, match_id, \
         rating_before, rating_after, volatility_before, volatility_after, timestamp, adjustment_type) \
         VALUES ";
 
@@ -302,8 +302,9 @@ impl DbClient {
                 let match_id = adjustment.match_id.map_or("NULL".to_string(), |id| id.to_string());
 
                 let value_tuple = format!(
-                    "({}, {}, {}, {}, {}, {}, {}, '{}', {})",
+                    "({}, {}, {}, {}, {}, {}, {}, {}, '{}', {})",
                     adjustment.player_id,
+                    adjustment.ruleset as i32,
                     player_rating_id,
                     match_id,
                     adjustment.rating_before,

--- a/src/database/db_structs.rs
+++ b/src/database/db_structs.rs
@@ -74,6 +74,7 @@ pub struct PlayerRating {
 #[derive(Debug, Clone, Serialize)]
 pub struct RatingAdjustment {
     pub player_id: i32,
+    pub ruleset: Ruleset,
     pub match_id: Option<i32>,
     pub rating_before: f64,
     pub rating_after: f64,

--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -100,6 +100,7 @@ impl DecayTracker {
 
             decay_ratings.push(RatingAdjustment {
                 player_id,
+                ruleset,
                 match_id: None,
                 rating_before: old_rating,
                 rating_after: new_rating,

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -318,6 +318,7 @@ impl OtrModel {
             // Create the adjustment
             let adjustment = RatingAdjustment {
                 player_id: *k,
+                ruleset: match_.ruleset,
                 match_id: Some(match_.id),
                 rating_before: player_rating.rating,
                 rating_after: v.mu,

--- a/src/model/rating_utils.rs
+++ b/src/model/rating_utils.rs
@@ -31,6 +31,7 @@ fn create_initial_ratings(player: &Player) -> Vec<PlayerRating> {
         let rating = initial_rating(player, &ruleset);
         let adjustment = RatingAdjustment {
             player_id: player.id,
+            ruleset,
             match_id: None,
             rating_before: 0.0,
             rating_after: rating,

--- a/src/model/structures/rating_adjustment_type.rs
+++ b/src/model/structures/rating_adjustment_type.rs
@@ -5,8 +5,8 @@ use std::convert::TryFrom;
 #[repr(u8)]
 pub enum RatingAdjustmentType {
     Initial = 0,
-    Match = 1,
-    Decay = 2
+    Decay = 1,
+    Match = 2
 }
 
 impl TryFrom<i32> for RatingAdjustmentType {
@@ -14,8 +14,8 @@ impl TryFrom<i32> for RatingAdjustmentType {
     fn try_from(v: i32) -> Result<Self, Self::Error> {
         match v {
             0 => Ok(RatingAdjustmentType::Initial),
-            1 => Ok(RatingAdjustmentType::Match),
-            2 => Ok(RatingAdjustmentType::Decay),
+            1 => Ok(RatingAdjustmentType::Decay),
+            2 => Ok(RatingAdjustmentType::Match),
             _ => Err(())
         }
     }

--- a/src/model/structures/rating_adjustment_type.rs
+++ b/src/model/structures/rating_adjustment_type.rs
@@ -32,13 +32,13 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_match() {
-        assert_eq!(RatingAdjustmentType::try_from(1), Ok(RatingAdjustmentType::Match));
+    fn test_convert_decay() {
+        assert_eq!(RatingAdjustmentType::try_from(1), Ok(RatingAdjustmentType::Decay));
     }
 
     #[test]
-    fn test_convert_decay() {
-        assert_eq!(RatingAdjustmentType::try_from(2), Ok(RatingAdjustmentType::Decay));
+    fn test_convert_match() {
+        assert_eq!(RatingAdjustmentType::try_from(2), Ok(RatingAdjustmentType::Match));
     }
 
     #[test]

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -40,6 +40,7 @@ pub fn generate_player_rating(
 
         adjustments.push(RatingAdjustment {
             player_id,
+            ruleset,
             adjustment_type,
             match_id: None,
             rating_before,


### PR DESCRIPTION
# Dependencies

- [x] https://github.com/osu-tournament-rating/otr-api/pull/568

# Changes

- Adds the `ruleset` property to `RatingAdjustment` and updates various parts of the program to store it.
- Saves the `ruleset` property to the `rating_adjustments` table.