### PR TITLE
Fix bugs with player fetching and rating processing

### DIFF
--- a/src/database/db.rs
+++ b/src/database/db.rs
@@ -214,7 +214,7 @@ impl DbClient {
                 "SELECT p.id AS player_id, p.username AS username, \
         p.country AS country, prd.ruleset AS ruleset, prd.earliest_global_rank AS earliest_global_rank,\
           prd.global_rank AS global_rank FROM players p \
-        LEFT JOIN player_osu_ruleset_data prd ON prd.player_id = p.id \
+        JOIN player_osu_ruleset_data prd ON prd.player_id = p.id \
         ORDER BY p.id",
                 &[]
             )
@@ -222,32 +222,42 @@ impl DbClient {
             .unwrap();
 
         let mut current_player_id = -1;
-        for row in rows {
-            if row.get::<_, i32>("player_id") != current_player_id {
+        let mut current_ruleset_data: Vec<RulesetData> = Vec::new();
+        
+        for (i, row) in rows.iter().enumerate() {
+            let player_id = row.get::<_, i32>("player_id");
+            
+            // If we're at the end of the loop, or the player id has changed, save the previous player's ruleset data.
+            if player_id != current_player_id || i == rows.len() - 1 {
+                // If they had no ruleset data, the `current_ruleset_data` vector will be empty.
+                if current_player_id != -1 {
+                    if let Some(last_player) = players.last_mut() {
+                        last_player.ruleset_data = Some(current_ruleset_data.clone());
+                    }
+                }
+                
+                // Start a new player
+                current_player_id = player_id;
+
+                // Clear out previous player's ruleset data
+                current_ruleset_data.clear();
+                
                 let player = Player {
                     id: row.get("player_id"),
                     username: row.get("username"),
                     country: row.get("country"),
-                    ruleset_data: self.ruleset_data_from_row(&row).map(|data| vec![data])
+                    // Saved when the player id changes or the last row is reached.
+                    ruleset_data: Some(Vec::new())
                 };
                 players.push(player);
-                current_player_id = row.get("player_id");
-            } else {
-                // Same player, new ruleset data
-
-                let data = self.ruleset_data_from_row(&row);
-                if let Some(ruleset_data) = data {
-                    players
-                        .last_mut()
-                        .unwrap()
-                        .ruleset_data
-                        .clone()
-                        .unwrap_or_default()
-                        .push(ruleset_data);
-                }
+            }
+            
+            // Push this row's ruleset data
+            if let Some(ruleset_data) = self.ruleset_data_from_row(&row) {
+                current_ruleset_data.push(ruleset_data);
             }
         }
-
+        
         info!("Players fetched");
         players
     }


### PR DESCRIPTION
Closes #100 

This PR...

- Updates the `get_players` logic to ensure the last fetched player is correctly saved.
- Fixes a bug in the `get_players` logic which only saved one `RulesetData` struct per player. I think what happened is the first ruleset data would be used correctly, and any subsequent ones would be defaulted.
- Relies on the rating tracker as a source of truth for whether a player should be included in the system. Previously, it was assumed that iterating through match -> game -> score to derive the `player_id` would function identically to `rating_tracker.get_rating(...)`.
- Thoroughly documents the situations in which a player would be included in match data but not in the rating tracker. This happens when a player has no `player_osu_ruleset_data` table entry.