### PR TITLE
Algorithm: Initiate rating and volatility decays after `2019-01-01`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.idea
 .vscode/
 .aider*
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 **/*.idea
 .vscode/
 .aider*
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# otr-processor
+
+Rust rating calculation engine using PlackettLuce model with OpenSkill.
+
+## Commands
+
+```bash
+cargo build                         # Debug build
+cargo build --release               # Release build
+cargo run --release                 # Run processor
+cargo test --all-features           # All tests
+cargo +nightly fmt                  # Format code
+cargo clippy --all-features --all-targets  # Lint (nightly)
+```
+
+## Environment
+
+```bash
+# Required
+CONNECTION_STRING=postgresql://user:pass@localhost:5432/database
+
+# Optional
+RUST_LOG=info                       # trace|debug|info|warn|error
+IGNORE_CONSTRAINTS=false            # Skip table access checks
+RABBITMQ_URL=amqp://admin:admin@localhost:5672
+RABBITMQ_ROUTING_KEY=processing.stats.tournaments
+```
+
+## Architecture
+
+```
+src/
+├── main.rs           # Entry point, orchestration
+├── model/            # Rating calculation core
+│   ├── otr_model.rs  # PlackettLuce implementation
+│   ├── decay.rs      # Rating/volatility decay
+│   ├── constants.rs  # Model parameters
+│   └── structures/   # Ruleset enum, adjustment types
+├── database/         # PostgreSQL integration
+│   ├── db.rs         # Queries, transaction management
+│   └── db_structs.rs # Data models
+└── messaging/        # RabbitMQ publishing
+```
+
+## Key Concepts
+
+- **Rulesets**: Standard, Taiko, Catch, Mania (Other/4K/7K)
+- **Two-method calculation**: Method A (skip missed games) + Method B (assume last place)
+- **Decay**: Applies after 184 days inactivity, floor at 1000 or peak-based minimum
+- **Weekly updates**: Ratings recalculated Tuesday 12:00 UTC
+
+## Model Constants (src/model/constants.rs)
+
+- `DEFAULT_VOLATILITY=400.0` - Initial uncertainty
+- `DECAY_DAYS=184` - Inactivity threshold
+- `DECAY_RATE=3.0` - Points lost per cycle
+- `WEIGHT_A=0.9` / `WEIGHT_B=0.1` - Method weights
+
+## Database Patterns
+
+- Uses `tokio-postgres` with async transactions
+- Batch processing: 500 matches, 5000 players per batch
+- Transaction guard with auto-rollback on error

--- a/src/messaging/config.rs
+++ b/src/messaging/config.rs
@@ -155,8 +155,8 @@ impl Default for RabbitMqConfig {
         let routing_key = "processing.stats.tournaments".to_string();
         Self {
             host: "localhost".to_string(),
-            username: "guest".to_string(),
-            password: "guest".to_string(),
+            username: "admin".to_string(),
+            password: "admin".to_string(),
             vhost: "/".to_string(),
             port: 5672,
             exchange: routing_key.clone(),
@@ -278,8 +278,8 @@ mod tests {
         let config = RabbitMqConfig::from_url("amqp://localhost").unwrap();
 
         assert_eq!(config.host, "localhost");
-        assert_eq!(config.username, "guest");
-        assert_eq!(config.password, "guest");
+        assert_eq!(config.username, "admin");
+        assert_eq!(config.password, "admin");
         assert_eq!(config.port, 5672);
         assert_eq!(config.vhost, "/");
     }
@@ -289,8 +289,8 @@ mod tests {
         let config = RabbitMqConfig::default();
 
         assert_eq!(config.host, "localhost");
-        assert_eq!(config.username, "guest");
-        assert_eq!(config.password, "guest");
+        assert_eq!(config.username, "admin");
+        assert_eq!(config.password, "admin");
         assert_eq!(config.vhost, "/");
         assert_eq!(config.port, 5672);
         assert_eq!(config.exchange, "processing.stats.tournaments");

--- a/src/model/constants.rs
+++ b/src/model/constants.rs
@@ -64,7 +64,5 @@ pub const STANDARD_MATCH_LENGTH: f64 = 8.0;
 /// unfair decay. No decay should occur before this date.
 pub fn decay_start_date() -> chrono::DateTime<chrono::FixedOffset> {
     use chrono::{TimeZone, Utc};
-    Utc.with_ymd_and_hms(2019, 1, 1, 0, 0, 0)
-        .unwrap()
-        .fixed_offset()
+    Utc.with_ymd_and_hms(2019, 1, 1, 0, 0, 0).unwrap().fixed_offset()
 }

--- a/src/model/constants.rs
+++ b/src/model/constants.rs
@@ -56,3 +56,15 @@ pub const GAME_CORRECTION_CONSTANT: f64 = 0.5;
 /// Constant representing a typical match length (in games), used for
 /// game correction weighting
 pub const STANDARD_MATCH_LENGTH: f64 = 8.0;
+
+/// Returns the earliest date at which decay (rating or volatility) is allowed to occur.
+///
+/// Due to limited accessible tournament data before ~May 2018 (only official World Cups),
+/// players active in community tournaments before then appear inactive and accumulate
+/// unfair decay. No decay should occur before this date.
+pub fn decay_start_date() -> chrono::DateTime<chrono::FixedOffset> {
+    use chrono::{TimeZone, Utc};
+    Utc.with_ymd_and_hms(2019, 1, 1, 0, 0, 0)
+        .unwrap()
+        .fixed_offset()
+}

--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -8,7 +8,9 @@
 /// - Wednesday Decay: All decay adjustments occur at Wednesday 12:00 UTC
 /// - Unified Adjustments: Rating and volatility changes combined into single adjustments
 use super::{
-    constants::{DECAY_DAYS, DECAY_MINIMUM, DECAY_RATE, DECAY_VOLATILITY_GROWTH_RATE, VOLATILITY_DECAY_CAP},
+    constants::{
+        decay_start_date, DECAY_DAYS, DECAY_MINIMUM, DECAY_RATE, DECAY_VOLATILITY_GROWTH_RATE, VOLATILITY_DECAY_CAP
+    },
     structures::rating_adjustment_type::RatingAdjustmentType
 };
 use crate::{
@@ -110,6 +112,11 @@ impl UnifiedDecaySystem {
             timestamps.push(current);
             current += Duration::weeks(1);
         }
+
+        // Filter out Wednesdays before the decay start date to prevent unfair decay
+        // for players active in community tournaments before accessible data begins (~May 2018)
+        let start = decay_start_date();
+        timestamps.retain(|t| *t >= start);
 
         timestamps
     }
@@ -297,7 +304,10 @@ impl Default for UnifiedDecaySystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{model::structures::ruleset::Ruleset, utils::test_utils::generate_player_rating};
+    use crate::{
+        model::{constants::decay_start_date, structures::ruleset::Ruleset},
+        utils::test_utils::generate_player_rating
+    };
     use approx::assert_abs_diff_eq;
     use chrono::{Datelike, TimeZone, Timelike, Utc};
 
@@ -1155,5 +1165,138 @@ mod tests {
         assert_eq!(volatility_count, expected_active);
         assert_eq!(decay_count, expected_inactive);
         assert_eq!(total_count, all_wednesdays.len());
+    }
+
+    // --- Decay window start date tests ---
+
+    #[test]
+    fn test_no_decay_before_start_date() {
+        // No decay adjustments should be created for periods entirely before 2019-01-01
+        let mut system = UnifiedDecaySystem::new();
+        let last_played = Utc.with_ymd_and_hms(2017, 1, 1, 12, 0, 0).unwrap().fixed_offset();
+        let mut ratings = vec![generate_player_rating(
+            1,
+            Ruleset::Osu,
+            1500.0,
+            200.0,
+            2,
+            Some(last_played),
+            Some(last_played)
+        )];
+
+        // Establish baseline
+        let baseline = Utc.with_ymd_and_hms(2018, 1, 1, 12, 0, 0).unwrap().fixed_offset();
+        apply_decay_up_to(&mut system, &mut ratings, baseline);
+
+        // Process up to a date still before 2019-01-01
+        let before_cutoff = Utc.with_ymd_and_hms(2018, 12, 1, 12, 0, 0).unwrap().fixed_offset();
+        let count = apply_decay_up_to(&mut system, &mut ratings, before_cutoff);
+
+        assert_eq!(count, 0, "No decay adjustments should occur before 2019-01-01");
+    }
+
+    #[test]
+    fn test_decay_starts_on_first_wednesday_after_start_date() {
+        // 2019-01-01 is a Tuesday, so the first decay Wednesday should be 2019-01-02
+        let start = decay_start_date();
+        let first_wednesday = Utc.with_ymd_and_hms(2019, 1, 2, 12, 0, 0).unwrap().fixed_offset();
+
+        // Get Wednesdays spanning the start date boundary
+        let from = Utc.with_ymd_and_hms(2018, 12, 20, 12, 0, 0).unwrap().fixed_offset();
+        let to = Utc.with_ymd_and_hms(2019, 1, 10, 12, 0, 0).unwrap().fixed_offset();
+        let wednesdays = UnifiedDecaySystem::get_wednesdays_between(from, to);
+
+        assert!(!wednesdays.is_empty(), "Should have at least one Wednesday");
+        assert_eq!(
+            wednesdays[0], first_wednesday,
+            "First decay Wednesday should be 2019-01-02 (day after start date)"
+        );
+        // All Wednesdays should be on or after the start date
+        for w in &wednesdays {
+            assert!(*w >= start, "Wednesday {w} should be on or after decay start date");
+        }
+    }
+
+    #[test]
+    fn test_no_volatility_decay_before_start_date() {
+        // Active players should also get no volatility decay before the cutoff
+        let mut system = UnifiedDecaySystem::new();
+        let last_played = Utc.with_ymd_and_hms(2018, 6, 1, 12, 0, 0).unwrap().fixed_offset();
+        let mut ratings = vec![generate_player_rating(
+            1,
+            Ruleset::Osu,
+            1500.0,
+            200.0,
+            2,
+            Some(last_played),
+            Some(last_played)
+        )];
+
+        // Establish baseline
+        apply_decay_up_to(&mut system, &mut ratings, last_played);
+
+        // Process to a date before the cutoff
+        let before_cutoff = Utc.with_ymd_and_hms(2018, 12, 31, 12, 0, 0).unwrap().fixed_offset();
+        let count = apply_decay_up_to(&mut system, &mut ratings, before_cutoff);
+
+        assert_eq!(count, 0, "No volatility decay should occur before 2019-01-01");
+    }
+
+    #[test]
+    fn test_get_wednesdays_between_filters_before_start_date() {
+        // Wednesdays generated entirely before the start date should be filtered out
+        let from = Utc.with_ymd_and_hms(2018, 11, 1, 12, 0, 0).unwrap().fixed_offset();
+        let to = Utc.with_ymd_and_hms(2018, 12, 31, 12, 0, 0).unwrap().fixed_offset();
+
+        let wednesdays = UnifiedDecaySystem::get_wednesdays_between(from, to);
+        assert!(
+            wednesdays.is_empty(),
+            "All Wednesdays before 2019-01-01 should be filtered out, got {} Wednesdays",
+            wednesdays.len()
+        );
+    }
+
+    #[test]
+    fn test_decay_spanning_start_date_boundary() {
+        // A decay window crossing 2019-01-01 should only produce post-cutoff adjustments
+        let mut system = UnifiedDecaySystem::new();
+
+        // Player last played in 2017, so they're well past the inactivity threshold
+        let last_played = Utc.with_ymd_and_hms(2017, 1, 1, 12, 0, 0).unwrap().fixed_offset();
+        let mut ratings = vec![generate_player_rating(
+            1,
+            Ruleset::Osu,
+            1500.0,
+            200.0,
+            2,
+            Some(last_played),
+            Some(last_played)
+        )];
+
+        // Establish baseline before the cutoff
+        let baseline = Utc.with_ymd_and_hms(2018, 11, 1, 12, 0, 0).unwrap().fixed_offset();
+        apply_decay_up_to(&mut system, &mut ratings, baseline);
+
+        // Process across the boundary into 2019
+        let after_cutoff = Utc.with_ymd_and_hms(2019, 2, 1, 12, 0, 0).unwrap().fixed_offset();
+        let count = apply_decay_up_to(&mut system, &mut ratings, after_cutoff);
+
+        assert!(count > 0, "Should have decay adjustments after 2019-01-01");
+
+        // All adjustments should be on or after decay_start_date
+        let start = decay_start_date();
+        let decay_adjs: Vec<_> = ratings[0]
+            .adjustments
+            .iter()
+            .filter(|a| a.adjustment_type == Decay || a.adjustment_type == VolatilityDecay)
+            .collect();
+
+        for adj in &decay_adjs {
+            assert!(
+                adj.timestamp >= start,
+                "Adjustment at {} should be on or after decay start date",
+                adj.timestamp
+            );
+        }
     }
 }


### PR DESCRIPTION
This is an algorithm change which prevents the creation of `Decay` and `VolatilityDecay` rating adjustments before `2019-01-01`. The justification for this change can be read in #140.

Closes #140 

Azer before:

<img width="1295" height="826" alt="image" src="https://github.com/user-attachments/assets/1e253ff9-b90e-48c6-9a4a-212c9e9a598d" />

Azer after:

<img width="1295" height="826" alt="image" src="https://github.com/user-attachments/assets/515d798e-866e-4aff-87ff-ea5c41d90fe1" />
