### PR TITLE
Lowercase environment names in deployment workflows

### DIFF
--- a/.github/workflows/deploy-trigger.yml
+++ b/.github/workflows/deploy-trigger.yml
@@ -11,11 +11,11 @@ on:
       environment:
         description: "Environment to deploy to"
         required: true
-        default: "Staging"
+        default: "staging"
         type: choice
         options:
-          - Staging
-          - Production
+          - staging
+          - production
 
 jobs:
   determine-environment:
@@ -29,9 +29,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "target=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-            echo "target=Staging" >> $GITHUB_OUTPUT
+            echo "target=staging" >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref }}" =~ ^refs/tags/[0-9]{4}\.[0-9]{2}\.[0-9]{2}(\.[0-9]+)?$ ]]; then
-            echo "target=Production" >> $GITHUB_OUTPUT
+            echo "target=production" >> $GITHUB_OUTPUT
           else
             echo "target=none" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,10 @@ jobs:
         id: set-tag
         run: |
           image_prefix="${{ secrets.DOCKERHUB_USERNAME }}/otr-processor"
-          if [[ "${{ inputs.target }}" == "Staging" ]]; then
+          if [[ "${{ inputs.target }}" == "staging" ]]; then
             echo "PRIMARY_TAG=staging" >> $GITHUB_OUTPUT
             echo "TAGS=${image_prefix}:staging" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.target }}" == "Production" && "${{ github.ref_type }}" == "tag" ]]; then
+          elif [[ "${{ inputs.target }}" == "production" && "${{ github.ref_type }}" == "tag" ]]; then
             echo "PRIMARY_TAG=${{ github.ref_name }}" >> $GITHUB_OUTPUT
             {
               echo 'TAGS<<EOF'


### PR DESCRIPTION
- Lowercase `staging`/`production` in `deploy.yml` and `deploy-trigger.yml` choice options, defaults, target comparisons, and trigger outputs

The GitHub Environments named `Staging` and `Production` must be renamed to lowercase before this is merged.