### PR TITLE
Numerous computation bug fixes

### DIFF
--- a/src/database/db.rs
+++ b/src/database/db.rs
@@ -348,15 +348,26 @@ impl DbClient {
 
     async fn fetch_player_batch(&self, after_id: i32) -> Vec<Player> {
         let query = "
+            WITH player_batch AS (
+                SELECT p.id
+                FROM players p
+                WHERE p.id > $1
+                  AND EXISTS (
+                      SELECT 1
+                      FROM player_osu_ruleset_data prd
+                      WHERE prd.player_id = p.id
+                  )
+                ORDER BY p.id
+                LIMIT $2
+            )
             SELECT p.id AS player_id, p.username AS username,
                    p.country AS country, prd.ruleset AS ruleset,
                    prd.earliest_global_rank AS earliest_global_rank,
                    prd.global_rank AS global_rank
-            FROM players p
+            FROM player_batch pb
+            JOIN players p ON p.id = pb.id
             JOIN player_osu_ruleset_data prd ON prd.player_id = p.id
-            WHERE p.id > $1
-            ORDER BY p.id
-            LIMIT $2";
+            ORDER BY p.id, prd.ruleset";
 
         let rows = self
             .client
@@ -409,7 +420,7 @@ impl DbClient {
 
     fn ruleset_data_from_row(&self, row: &Row) -> Option<RulesetData> {
         let ruleset = row.try_get::<_, i32>("ruleset");
-        let global_rank = row.try_get::<_, i32>("global_rank");
+        let global_rank = row.try_get::<_, Option<i32>>("global_rank");
         let earliest_global_rank = row.try_get::<_, Option<i32>>("earliest_global_rank");
 
         if let (Ok(ruleset_val), Ok(global_rank_val), Ok(earliest_global_rank_val)) =
@@ -437,6 +448,101 @@ impl DbClient {
 
         self.save_ratings_and_adjustments_with_mapping(&player_ratings).await;
         self.insert_or_update_highest_ranks(player_ratings).await;
+    }
+
+    /// Snapshots the match-linked rating adjustments that exist before a
+    /// recomputation replaces them. The temporary table is scoped to the
+    /// current transaction and is used to invalidate rating-dependent
+    /// tournament statistics after the new adjustments are written.
+    pub async fn snapshot_match_rating_adjustments(&self) {
+        self.client
+            .batch_execute(
+                "
+                CREATE TEMPORARY TABLE previous_match_rating_adjustments
+                ON COMMIT DROP
+                AS
+                SELECT
+                    ra.match_id,
+                    ra.player_id,
+                    ra.ruleset,
+                    ra.rating_before,
+                    ra.rating_after,
+                    ra.volatility_before,
+                    ra.volatility_after,
+                    m.tournament_id
+                FROM rating_adjustments ra
+                JOIN matches m ON m.id = ra.match_id
+                WHERE ra.match_id IS NOT NULL;
+
+                CREATE INDEX previous_match_rating_adjustments_identity_idx
+                    ON previous_match_rating_adjustments (match_id, player_id);
+                "
+            )
+            .await
+            .expect("Failed to snapshot match rating adjustments");
+    }
+
+    /// Returns accepted tournaments whose match-linked rating adjustments
+    /// differ from the snapshot created by `snapshot_match_rating_adjustments`.
+    /// Regenerated database IDs, creation timestamps, and non-match adjustments
+    /// are intentionally excluded from the comparison.
+    pub async fn get_tournaments_with_changed_rating_adjustments(&self) -> Vec<i32> {
+        let rows = self
+            .client
+            .query(
+                "
+                WITH current_match_rating_adjustments AS (
+                    SELECT
+                        ra.match_id,
+                        ra.player_id,
+                        ra.ruleset,
+                        ra.rating_before,
+                        ra.rating_after,
+                        ra.volatility_before,
+                        ra.volatility_after,
+                        m.tournament_id
+                    FROM rating_adjustments ra
+                    JOIN matches m ON m.id = ra.match_id
+                    WHERE ra.match_id IS NOT NULL
+                ),
+                changed_tournaments AS (
+                    SELECT
+                        previous.tournament_id AS previous_tournament_id,
+                        current.tournament_id AS current_tournament_id
+                    FROM previous_match_rating_adjustments previous
+                    FULL OUTER JOIN current_match_rating_adjustments current
+                        ON current.match_id = previous.match_id
+                        AND current.player_id = previous.player_id
+                    WHERE previous.match_id IS NULL
+                        OR current.match_id IS NULL
+                        OR previous.tournament_id IS DISTINCT FROM current.tournament_id
+                        OR previous.ruleset IS DISTINCT FROM current.ruleset
+                        OR previous.rating_before IS DISTINCT FROM current.rating_before
+                        OR previous.rating_after IS DISTINCT FROM current.rating_after
+                        OR previous.volatility_before IS DISTINCT FROM current.volatility_before
+                        OR previous.volatility_after IS DISTINCT FROM current.volatility_after
+                ),
+                changed_tournament_ids AS (
+                    SELECT previous_tournament_id AS tournament_id
+                    FROM changed_tournaments
+                    WHERE previous_tournament_id IS NOT NULL
+                    UNION
+                    SELECT current_tournament_id AS tournament_id
+                    FROM changed_tournaments
+                    WHERE current_tournament_id IS NOT NULL
+                )
+                SELECT changed.tournament_id
+                FROM changed_tournament_ids changed
+                JOIN tournaments t ON t.id = changed.tournament_id
+                WHERE t.verification_status = 4
+                ORDER BY changed.tournament_id
+                ",
+                &[]
+            )
+            .await
+            .expect("Failed to compare match rating adjustments");
+
+        rows.iter().map(|row| row.get("tournament_id")).collect()
     }
 
     async fn save_ratings_and_adjustments_with_mapping(&self, player_ratings: &&[PlayerRating]) {
@@ -587,7 +693,12 @@ impl DbClient {
 
         for rating in player_ratings {
             if let Some(Some(current_rank)) = current_highest_ranks.get(&(rating.player_id, rating.ruleset)) {
-                if rating.global_rank < current_rank.global_rank {
+                let global_rank_improved = rating.global_rank > 0
+                    && (current_rank.global_rank == 0 || rating.global_rank < current_rank.global_rank);
+                let country_rank_improved = rating.country_rank > 0
+                    && (current_rank.country_rank == 0 || rating.country_rank < current_rank.country_rank);
+
+                if global_rank_improved || country_rank_improved {
                     updates.push(rating);
                 }
             } else {
@@ -686,12 +797,29 @@ impl DbClient {
 
     async fn update_highest_rank(&self, player_id: i32, player_rating: &PlayerRating) {
         let timestamp = player_rating.adjustments.last().unwrap().timestamp;
-        let query = "UPDATE player_highest_ranks SET global_rank = $1, global_rank_date = $2, country_rank = $3, country_rank_date = $4 WHERE player_id = $5 AND ruleset = $6";
+        let query = "
+            UPDATE player_highest_ranks
+            SET global_rank = CASE
+                    WHEN $1 > 0 AND (global_rank = 0 OR $1 < global_rank) THEN $1
+                    ELSE global_rank
+                END,
+                global_rank_date = CASE
+                    WHEN $1 > 0 AND (global_rank = 0 OR $1 < global_rank) THEN $2
+                    ELSE global_rank_date
+                END,
+                country_rank = CASE
+                    WHEN $3 > 0 AND (country_rank = 0 OR $3 < country_rank) THEN $3
+                    ELSE country_rank
+                END,
+                country_rank_date = CASE
+                    WHEN $3 > 0 AND (country_rank = 0 OR $3 < country_rank) THEN $2
+                    ELSE country_rank_date
+                END
+            WHERE player_id = $4 AND ruleset = $5";
         let values: &[&(dyn ToSql + Sync)] = &[
             &player_rating.global_rank,
             &timestamp,
             &player_rating.country_rank,
-            &timestamp,
             &player_id,
             &(player_rating.ruleset as i32)
         ];
@@ -776,7 +904,9 @@ impl DbClient {
     }
 
     pub async fn begin_transaction(&self) -> Result<DbTransactionGuard, Error> {
-        self.client.batch_execute("BEGIN").await?;
+        self.client
+            .batch_execute("BEGIN ISOLATION LEVEL REPEATABLE READ")
+            .await?;
         Ok(DbTransactionGuard::new(Arc::clone(&self.client)))
     }
 

--- a/src/database/db_structs.rs
+++ b/src/database/db_structs.rs
@@ -20,7 +20,7 @@ pub struct Player {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RulesetData {
     pub ruleset: Ruleset,
-    pub global_rank: i32,
+    pub global_rank: Option<i32>,
     pub earliest_global_rank: Option<i32>
 }
 
@@ -33,6 +33,16 @@ pub struct Match {
     // Populated in the db query (uses the tournament's ruleset)
     pub ruleset: Ruleset,
     pub games: Vec<Game>
+}
+
+impl Match {
+    /// The point in time at which this match affects ratings.
+    ///
+    /// Match results are applied when the match ends. Some legacy matches do not
+    /// have an end time, so their start time remains the compatibility fallback.
+    pub fn rating_timestamp(&self) -> DateTime<FixedOffset> {
+        self.end_time.unwrap_or(self.start_time)
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@ use otr_processor::{
     model::{otr_model::OtrModel, rating_utils::create_initial_ratings},
     utils::test_utils::generate_country_mapping_players
 };
-use std::{collections::HashMap, time::Instant};
+use std::{
+    collections::{BTreeSet, HashMap},
+    time::Instant
+};
 use tracing::{debug, error, info, warn};
 use tracing_indicatif::IndicatifLayer;
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -71,6 +74,7 @@ async fn main() {
             "Fetched tournament information for {} tournaments.",
             tournament_info.len()
         );
+        let all_tournament_ids: Vec<i32> = tournament_info.keys().copied().collect();
 
         // 3. Generate initial ratings
         let initial_ratings = create_initial_ratings(&players, &matches);
@@ -89,20 +93,52 @@ async fn main() {
         info!("Matches processed.");
 
         // 7. Save results in database
+        let track_rating_changes = rabbitmq_publisher.is_some();
+        if track_rating_changes {
+            client.snapshot_match_rating_adjustments().await;
+        }
+
         client.save_results(&results).await;
         info!("Results saved to database.");
+
+        let rating_changed_tournament_ids = if track_rating_changes {
+            client.get_tournaments_with_changed_rating_adjustments().await
+        } else {
+            Vec::new()
+        };
 
         // 8. Remove lingering stats for tournaments/matches rejected since the last run
         client.delete_rejected_player_stats().await;
 
         // 9. Emit messages for tournaments needing stats refresh
         if let Some(ref mut publisher) = rabbitmq_publisher {
-            let all_tournament_ids: Vec<i32> = tournament_info.keys().cloned().collect();
+            let mut tournaments_needing_refresh: BTreeSet<i32> = client
+                .get_tournaments_needing_stats_refresh(&all_tournament_ids)
+                .await
+                .into_iter()
+                .collect();
 
-            let tournaments_needing_refresh = client.get_tournaments_needing_stats_refresh(&all_tournament_ids).await;
+            let rating_change_count = rating_changed_tournament_ids.len();
+            let unavailable_rating_changes = rating_changed_tournament_ids
+                .iter()
+                .filter(|tournament_id| !tournament_info.contains_key(tournament_id))
+                .count();
+            tournaments_needing_refresh.extend(
+                rating_changed_tournament_ids
+                    .into_iter()
+                    .filter(|tournament_id| tournament_info.contains_key(tournament_id))
+            );
 
-            let skipped = tournament_info.len() - tournaments_needing_refresh.len();
+            if unavailable_rating_changes > 0 {
+                warn!(
+                    unavailable_rating_changes,
+                    "Rating changes were detected for tournaments without currently processable matches"
+                );
+            }
+
+            let skipped = tournament_info.len().saturating_sub(tournaments_needing_refresh.len());
             info!(
+                rating_changed_tournaments = rating_change_count,
                 "Enqueueing {} of {} tournaments for stats refresh ({} unchanged)",
                 tournaments_needing_refresh.len(),
                 tournament_info.len(),

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -97,7 +97,10 @@ impl OtrModel {
 
         info!(match_count = matches.len(), "Starting to process matches");
 
-        for m in matches.iter() {
+        let mut matches = matches.iter().collect::<Vec<_>>();
+        matches.sort_by_key(|match_| (match_.rating_timestamp(), match_.id));
+
+        for m in matches {
             if m.games.is_empty() {
                 error!(match_id = m.id, match_name = %m.name, "Skipping match - no games found");
                 span.pb_inc(1);
@@ -138,7 +141,7 @@ impl OtrModel {
     /// 4. Combine results using weighted average
     /// 5. Update player ratings in the tracker
     fn process_match(&mut self, match_: &Match) {
-        self.apply_unified_decay(match_.start_time);
+        self.apply_unified_decay(match_.rating_timestamp());
         self.ensure_player_ratings(match_);
 
         let ratings_a = self.generate_ratings_a(match_);
@@ -422,7 +425,7 @@ impl OtrModel {
                 // Player not present in the rating tracker.
                 // Create a fallback initial rating for them and add to tracker.
 
-                let match_time = match_.end_time.unwrap_or(match_.start_time);
+                let match_time = match_.rating_timestamp();
                 let adjustment = RatingAdjustment {
                     player_id,
                     ruleset: match_.ruleset,
@@ -476,7 +479,7 @@ impl OtrModel {
             };
 
             // Create the adjustment
-            let match_time = match_.end_time.unwrap_or(match_.start_time);
+            let match_time = match_.rating_timestamp();
             let adjustment = RatingAdjustment {
                 player_id: *k,
                 ruleset: player_rating.ruleset,
@@ -1072,6 +1075,124 @@ mod tests {
         assert_eq!(
             match_adj.timestamp, start_time,
             "Match adjustment should fall back to start_time when end_time is None"
+        );
+    }
+
+    #[test]
+    fn test_process_sorts_matches_by_rating_timestamp() {
+        let initial_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap().fixed_offset();
+        let player_ratings = vec![
+            generate_player_rating(1, Osu, 1000.0, 100.0, 1, Some(initial_time), Some(initial_time)),
+            generate_player_rating(2, Osu, 1000.0, 100.0, 1, Some(initial_time), Some(initial_time)),
+        ];
+        let countries = generate_country_mapping_player_ratings(&player_ratings, "US");
+        let mut model = OtrModel::new(&player_ratings, &countries);
+
+        let placements = vec![generate_placement(1, 1), generate_placement(2, 2)];
+        let games = vec![generate_game(1, &placements)];
+        let late_ending_start = Utc.with_ymd_and_hms(2024, 1, 2, 10, 0, 0).unwrap().fixed_offset();
+        let early_ending_start = Utc.with_ymd_and_hms(2024, 1, 2, 11, 0, 0).unwrap().fixed_offset();
+
+        let late_ending_match = crate::database::db_structs::Match {
+            id: 2,
+            name: "Late-ending Match".to_string(),
+            ruleset: Osu,
+            start_time: late_ending_start,
+            end_time: Some(late_ending_start + Duration::hours(3)),
+            games: games.clone()
+        };
+        let early_ending_match = crate::database::db_structs::Match {
+            id: 1,
+            name: "Early-ending Match".to_string(),
+            ruleset: Osu,
+            start_time: early_ending_start,
+            end_time: Some(early_ending_start + Duration::hours(1)),
+            games
+        };
+
+        // Start-time ordering would process match 2 first; rating-time ordering
+        // correctly applies the result of match 1 first because it ends earlier.
+        model.process(&[late_ending_match, early_ending_match]);
+
+        let match_ids = model
+            .rating_tracker
+            .get_rating_adjustments(1, Osu)
+            .unwrap()
+            .into_iter()
+            .filter(|adjustment| adjustment.adjustment_type == RatingAdjustmentType::Match)
+            .map(|adjustment| adjustment.match_id.unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(match_ids, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_match_crossing_wednesday_decay_keeps_its_result() {
+        let initial_time = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap().fixed_offset();
+        let player_ratings = vec![
+            generate_player_rating(1, Osu, 1000.0, 100.0, 1, Some(initial_time), Some(initial_time)),
+            generate_player_rating(2, Osu, 1000.0, 100.0, 1, Some(initial_time), Some(initial_time)),
+        ];
+        let countries = generate_country_mapping_player_ratings(&player_ratings, "US");
+        let mut model = OtrModel::new(&player_ratings, &countries);
+
+        let placements = vec![generate_placement(1, 1), generate_placement(2, 2)];
+        let games = vec![generate_game(1, &placements)];
+        let first_start = Utc.with_ymd_and_hms(2024, 1, 1, 10, 0, 0).unwrap().fixed_offset();
+        let crossing_start = Utc.with_ymd_and_hms(2024, 1, 3, 11, 0, 0).unwrap().fixed_offset();
+        let final_start = Utc.with_ymd_and_hms(2024, 1, 3, 14, 0, 0).unwrap().fixed_offset();
+
+        let matches = [
+            crate::database::db_structs::Match {
+                id: 1,
+                name: "Baseline Match".to_string(),
+                ruleset: Osu,
+                start_time: first_start,
+                end_time: Some(first_start + Duration::hours(1)),
+                games: games.clone()
+            },
+            crate::database::db_structs::Match {
+                id: 2,
+                name: "Crossing Match".to_string(),
+                ruleset: Osu,
+                start_time: crossing_start,
+                end_time: Some(crossing_start + Duration::hours(2)),
+                games: games.clone()
+            },
+            crate::database::db_structs::Match {
+                id: 3,
+                name: "Following Match".to_string(),
+                ruleset: Osu,
+                start_time: final_start,
+                end_time: Some(final_start + Duration::hours(1)),
+                games
+            }
+        ];
+
+        for match_ in &matches {
+            model.process_match(match_);
+        }
+
+        let adjustments = model.rating_tracker.get_rating_adjustments(1, Osu).unwrap();
+        let match_adjustments = adjustments
+            .iter()
+            .filter(|adjustment| adjustment.adjustment_type == RatingAdjustmentType::Match)
+            .collect::<Vec<_>>();
+        let decay_time = Utc.with_ymd_and_hms(2024, 1, 3, 12, 0, 0).unwrap().fixed_offset();
+        let decay_index = adjustments
+            .iter()
+            .position(|adjustment| adjustment.timestamp == decay_time)
+            .expect("Expected decay at Wednesday noon before the crossing match result");
+        let crossing_index = adjustments
+            .iter()
+            .position(|adjustment| adjustment.match_id == Some(2))
+            .unwrap();
+
+        assert!(decay_index < crossing_index);
+        assert_eq!(match_adjustments[2].rating_before, match_adjustments[1].rating_after);
+        assert_eq!(
+            match_adjustments[2].volatility_before,
+            match_adjustments[1].volatility_after
         );
     }
 

--- a/src/model/rating_utils.rs
+++ b/src/model/rating_utils.rs
@@ -26,11 +26,14 @@ pub fn create_initial_ratings(players: &[Player], matches: &[Match]) -> Vec<Play
                 // Allows us to accurately set the timestamp of the initial rating adjustment
                 // and avoid creating initial adjustments for players who are inactive in
                 // any ruleset.
-                let match_time = match_.end_time.unwrap_or(match_.start_time);
+                let match_time = match_.rating_timestamp();
                 ruleset_activity
                     .entry(match_.ruleset)
                     .or_default()
                     .entry(score.player_id)
+                    .and_modify(|first_match_time| {
+                        *first_match_time = (*first_match_time).min(match_time);
+                    })
                     .or_insert(match_time);
             }
         }
@@ -104,8 +107,12 @@ fn initial_rating(player: &Player, ruleset: &Ruleset) -> f64 {
                 }
 
                 // Fallback: use global_rank from the respective ruleset
-                if let Some(ruleset_data) = data.iter().find(|rd| rd.ruleset == *ruleset) {
-                    return mu_from_rank(ruleset_data.global_rank, *ruleset);
+                if let Some(global_rank) = data
+                    .iter()
+                    .find(|rd| rd.ruleset == *ruleset)
+                    .and_then(|ruleset_data| ruleset_data.global_rank)
+                {
+                    return mu_from_rank(global_rank, *ruleset);
                 }
 
                 // If no data found, use fallback rating
@@ -115,7 +122,7 @@ fn initial_rating(player: &Player, ruleset: &Ruleset) -> f64 {
 
             // Handle other rulesets as normal
             let ruleset_data = data.iter().find(|rd| rd.ruleset == *ruleset);
-            let rank = ruleset_data.and_then(|rd| rd.earliest_global_rank.or(Some(rd.global_rank)));
+            let rank = ruleset_data.and_then(|rd| rd.earliest_global_rank.or(rd.global_rank));
 
             match rank {
                 Some(r) => mu_from_rank(r, *ruleset),
@@ -172,14 +179,15 @@ fn std_dev_from_ruleset(ruleset: Ruleset) -> f64 {
 #[cfg(test)]
 mod tests {
     use crate::{
-        database::db_structs::Player,
+        database::db_structs::{Player, RulesetData},
         model::{
             constants::{FALLBACK_RATING, INITIAL_RATING_CEILING, INITIAL_RATING_FLOOR},
             rating_utils::mu_from_rank,
             structures::ruleset::Ruleset::{Catch, Mania4k, Mania7k, Osu, Taiko}
         },
-        utils::test_utils::generate_ruleset_data
+        utils::test_utils::{generate_game, generate_match, generate_placement, generate_ruleset_data}
     };
+    use chrono::{Duration, TimeZone, Utc};
 
     #[test]
     fn test_mu_from_rank_maximum() {
@@ -254,6 +262,74 @@ mod tests {
     }
 
     #[test]
+    fn test_initial_rating_prefers_earliest_then_current_rank() {
+        let player_with_earliest_only = Player {
+            id: 1,
+            username: None,
+            country: None,
+            ruleset_data: Some(vec![RulesetData {
+                ruleset: Osu,
+                global_rank: None,
+                earliest_global_rank: Some(500)
+            }])
+        };
+        let player_with_current_only = Player {
+            id: 2,
+            username: None,
+            country: None,
+            ruleset_data: Some(vec![RulesetData {
+                ruleset: Osu,
+                global_rank: Some(750),
+                earliest_global_rank: None
+            }])
+        };
+        let player_without_rank = Player {
+            id: 3,
+            username: None,
+            country: None,
+            ruleset_data: Some(vec![RulesetData {
+                ruleset: Osu,
+                global_rank: None,
+                earliest_global_rank: None
+            }])
+        };
+
+        assert_eq!(
+            super::initial_rating(&player_with_earliest_only, &Osu),
+            mu_from_rank(500, Osu)
+        );
+        assert_eq!(
+            super::initial_rating(&player_with_current_only, &Osu),
+            mu_from_rank(750, Osu)
+        );
+        assert_eq!(super::initial_rating(&player_without_rank, &Osu), FALLBACK_RATING);
+    }
+
+    #[test]
+    fn test_initial_adjustment_uses_earliest_rating_timestamp() {
+        let player = Player {
+            id: 1,
+            username: None,
+            country: None,
+            ruleset_data: Some(vec![generate_ruleset_data(Osu, 500, None)])
+        };
+        let placements = vec![generate_placement(1, 1), generate_placement(2, 2)];
+        let games = vec![generate_game(1, &placements)];
+        let early_start = Utc.with_ymd_and_hms(2024, 1, 1, 10, 0, 0).unwrap().fixed_offset();
+        let late_start = Utc.with_ymd_and_hms(2024, 1, 2, 10, 0, 0).unwrap().fixed_offset();
+        let early_match = generate_match(1, Osu, &games, early_start);
+        let late_match = generate_match(2, Osu, &games, late_start);
+
+        let ratings = super::create_initial_ratings(&[player], &[late_match, early_match]);
+
+        assert_eq!(ratings.len(), 1);
+        assert_eq!(
+            ratings[0].adjustments[0].timestamp,
+            early_start + Duration::hours(1) - Duration::seconds(1)
+        );
+    }
+
+    #[test]
     fn test_mania4k_mania7k_initial_rating_logic() {
         use crate::model::structures::ruleset::Ruleset::*;
 
@@ -314,5 +390,30 @@ mod tests {
 
         assert_eq!(mania4k_rating_no_data, FALLBACK_RATING);
         assert_eq!(mania7k_rating_no_data, FALLBACK_RATING);
+
+        // A nullable current rank remains a valid row, but cannot seed a rating
+        // when osu!track also has no overall Mania history.
+        let player_with_null_mania_ranks = Player {
+            id: 4,
+            username: Some("TestPlayer4".to_string()),
+            country: None,
+            ruleset_data: Some(vec![
+                RulesetData {
+                    ruleset: ManiaOther,
+                    global_rank: None,
+                    earliest_global_rank: None
+                },
+                RulesetData {
+                    ruleset: Mania4k,
+                    global_rank: None,
+                    earliest_global_rank: None
+                },
+            ])
+        };
+
+        assert_eq!(
+            super::initial_rating(&player_with_null_mania_ranks, &Mania4k),
+            FALLBACK_RATING
+        );
     }
 }

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -93,7 +93,7 @@ pub fn generate_player_rating(
 pub fn generate_ruleset_data(ruleset: Ruleset, global_rank: i32, earliest_global_rank: Option<i32>) -> RulesetData {
     RulesetData {
         ruleset,
-        global_rank,
+        global_rank: Some(global_rank),
         earliest_global_rank
     }
 }

--- a/tests/database/db_tests.rs
+++ b/tests/database/db_tests.rs
@@ -1,4 +1,4 @@
-use chrono::{FixedOffset, Utc};
+use chrono::{DateTime, Duration, FixedOffset, Utc};
 use otr_processor::{
     database::{db::DbClient, db_structs::*},
     model::structures::{rating_adjustment_type::RatingAdjustmentType, ruleset::Ruleset}
@@ -32,7 +32,96 @@ async fn test_get_players() {
     let ruleset_data = players[0].ruleset_data.as_ref().unwrap();
     assert_eq!(ruleset_data.len(), 1);
     assert_eq!(ruleset_data[0].ruleset, Ruleset::Osu);
-    assert_eq!(ruleset_data[0].global_rank, 1000);
+    assert_eq!(ruleset_data[0].global_rank, Some(1000));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_players_keeps_all_rulesets_at_batch_boundary() {
+    init_test_env();
+    let test_db = TestDatabase::new().await.expect("Failed to create test database");
+    let admin_client = test_db.get_client().await.expect("Failed to get client");
+
+    admin_client
+        .batch_execute(
+            "
+            INSERT INTO players (username, osu_id, country)
+            SELECT 'BatchPlayer' || player_number, 100000 + player_number, 'US'
+            FROM generate_series(1, 5000) AS player_number;
+
+            INSERT INTO player_osu_ruleset_data (player_id, ruleset, pp, global_rank)
+            SELECT id, 0, 1000.0, id
+            FROM players;
+
+            INSERT INTO player_osu_ruleset_data (player_id, ruleset, pp, global_rank)
+            SELECT id, 1, 1000.0, id
+            FROM players
+            ORDER BY id DESC
+            LIMIT 1;
+            "
+        )
+        .await
+        .expect("Failed to seed players at the batch boundary");
+
+    let db_client = DbClient::connect(&test_db.connection_string, false)
+        .await
+        .expect("Failed to connect");
+    let players = db_client.get_players().await;
+
+    assert_eq!(players.len(), 5000);
+    let boundary_rulesets = players
+        .last()
+        .and_then(|player| player.ruleset_data.as_ref())
+        .expect("Boundary player should have ruleset data");
+    assert_eq!(boundary_rulesets.len(), 2);
+    assert_eq!(boundary_rulesets[0].ruleset, Ruleset::Osu);
+    assert_eq!(boundary_rulesets[1].ruleset, Ruleset::Taiko);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_players_keeps_earliest_rank_when_current_rank_is_null() {
+    init_test_env();
+    let test_db = TestDatabase::new().await.expect("Failed to create test database");
+    let admin_client = test_db.get_client().await.expect("Failed to get client");
+
+    let player_id: i32 = admin_client
+        .query_one(
+            "
+            INSERT INTO players (username, osu_id, country)
+            VALUES ('FormerlyRankedPlayer', 123456, 'US')
+            RETURNING id
+            ",
+            &[]
+        )
+        .await
+        .expect("Failed to insert player")
+        .get("id");
+    admin_client
+        .execute(
+            "
+            INSERT INTO player_osu_ruleset_data
+                (player_id, ruleset, pp, global_rank, earliest_global_rank)
+            VALUES ($1, 0, 0.0, NULL, 1234)
+            ",
+            &[&player_id]
+        )
+        .await
+        .expect("Failed to insert nullable current rank");
+
+    let db_client = DbClient::connect(&test_db.connection_string, false)
+        .await
+        .expect("Failed to connect");
+    let players = db_client.get_players().await;
+
+    assert_eq!(players.len(), 1);
+    let ruleset_data = players[0]
+        .ruleset_data
+        .as_ref()
+        .expect("Player should have ruleset data");
+    assert_eq!(ruleset_data.len(), 1);
+    assert_eq!(ruleset_data[0].global_rank, None);
+    assert_eq!(ruleset_data[0].earliest_global_rank, Some(1234));
 }
 
 #[tokio::test]
@@ -141,6 +230,316 @@ async fn test_save_results() {
 
     assert_eq!(rating_count, 2);
     assert_eq!(adjustment_count, 2); // We have 2 adjustments, one for each player rating
+}
+
+#[tokio::test]
+#[serial]
+async fn test_save_results_updates_global_and_country_highest_ranks_independently() {
+    init_test_env();
+    let test_db = TestDatabase::new().await.expect("Failed to create test database");
+    test_db.seed_test_data().await.expect("Failed to seed test data");
+
+    let admin_client = test_db.get_client().await.expect("Failed to get client");
+    admin_client
+        .execute(
+            "UPDATE player_highest_ranks SET country_rank = 0 WHERE player_id = 3 AND ruleset = 0",
+            &[]
+        )
+        .await
+        .expect("Failed to seed an unknown country rank");
+
+    let timestamp = DateTime::parse_from_rfc3339("2025-02-03T04:05:06+00:00").unwrap();
+    let player_ratings = vec![
+        player_rating_with_ranks(1, 0, 50, timestamp),
+        player_rating_with_ranks(2, 1500, 250, timestamp),
+        player_rating_with_ranks(3, 3000, 30, timestamp),
+    ];
+
+    let db_client = DbClient::connect(&test_db.connection_string, false)
+        .await
+        .expect("Failed to connect");
+    db_client.save_results(&player_ratings).await;
+
+    let rows = admin_client
+        .query(
+            "
+            SELECT player_id, global_rank, global_rank_date, country_rank, country_rank_date
+            FROM player_highest_ranks
+            WHERE player_id = ANY($1)
+            ORDER BY player_id
+            ",
+            &[&vec![1_i32, 2, 3]]
+        )
+        .await
+        .expect("Failed to fetch highest ranks");
+    let original_timestamp = DateTime::parse_from_rfc3339("2024-01-01T00:00:00+00:00").unwrap();
+
+    assert_eq!(rows.len(), 3);
+
+    // An unknown global rank does not replace the peak, while an improved country rank does.
+    assert_eq!(rows[0].get::<_, i32>("global_rank"), 1000);
+    assert_eq!(
+        rows[0].get::<_, DateTime<FixedOffset>>("global_rank_date"),
+        original_timestamp
+    );
+    assert_eq!(rows[0].get::<_, i32>("country_rank"), 50);
+    assert_eq!(rows[0].get::<_, DateTime<FixedOffset>>("country_rank_date"), timestamp);
+
+    // A global improvement does not overwrite a better stored country peak.
+    assert_eq!(rows[1].get::<_, i32>("global_rank"), 1500);
+    assert_eq!(rows[1].get::<_, DateTime<FixedOffset>>("global_rank_date"), timestamp);
+    assert_eq!(rows[1].get::<_, i32>("country_rank"), 200);
+    assert_eq!(
+        rows[1].get::<_, DateTime<FixedOffset>>("country_rank_date"),
+        original_timestamp
+    );
+
+    // A real country rank replaces a stored zero without changing the equal global peak.
+    assert_eq!(rows[2].get::<_, i32>("global_rank"), 3000);
+    assert_eq!(
+        rows[2].get::<_, DateTime<FixedOffset>>("global_rank_date"),
+        original_timestamp
+    );
+    assert_eq!(rows[2].get::<_, i32>("country_rank"), 30);
+    assert_eq!(rows[2].get::<_, DateTime<FixedOffset>>("country_rank_date"), timestamp);
+}
+
+fn player_rating_with_ranks(
+    player_id: i32,
+    global_rank: i32,
+    country_rank: i32,
+    timestamp: DateTime<FixedOffset>
+) -> PlayerRating {
+    PlayerRating {
+        id: 0,
+        player_id,
+        ruleset: Ruleset::Osu,
+        rating: 1500.0,
+        volatility: 200.0,
+        percentile: 0.5,
+        global_rank,
+        country_rank,
+        adjustments: vec![RatingAdjustment {
+            player_id,
+            adjustment_type: RatingAdjustmentType::Initial,
+            ruleset: Ruleset::Osu,
+            rating_before: 1500.0,
+            volatility_before: 200.0,
+            rating_after: 1500.0,
+            volatility_after: 200.0,
+            timestamp,
+            match_id: None
+        }]
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_detects_tournaments_with_changed_match_rating_adjustments() {
+    init_test_env();
+    let test_db = TestDatabase::new().await.expect("Failed to create test database");
+    test_db.seed_test_data().await.expect("Failed to seed test data");
+
+    let admin_client = test_db.get_client().await.expect("Failed to get client");
+    let identifiers = admin_client
+        .query_one(
+            "
+            SELECT m.id AS match_id, m.tournament_id
+            FROM matches m
+            ORDER BY m.id
+            LIMIT 1
+            ",
+            &[]
+        )
+        .await
+        .expect("Failed to fetch tournament identifiers");
+    let match_id: i32 = identifiers.get("match_id");
+    let tournament_id: i32 = identifiers.get("tournament_id");
+    let timestamp = DateTime::parse_from_rfc3339("2025-02-03T04:05:06+00:00").unwrap();
+    let previous_ratings = vec![player_rating_with_match_adjustment(1, match_id, 1500.0, timestamp)];
+
+    let db_client = DbClient::connect(&test_db.connection_string, false)
+        .await
+        .expect("Failed to connect");
+
+    let mut initial_transaction = db_client
+        .begin_transaction()
+        .await
+        .expect("Failed to begin transaction");
+    db_client.save_results(&previous_ratings).await;
+    initial_transaction
+        .commit()
+        .await
+        .expect("Failed to commit initial ratings");
+
+    // Rewriting identical adjustment values should not invalidate the tournament.
+    let mut unchanged_transaction = db_client
+        .begin_transaction()
+        .await
+        .expect("Failed to begin transaction");
+    db_client.snapshot_match_rating_adjustments().await;
+    db_client.save_results(&previous_ratings).await;
+    assert!(db_client
+        .get_tournaments_with_changed_rating_adjustments()
+        .await
+        .is_empty());
+    unchanged_transaction
+        .rollback()
+        .await
+        .expect("Failed to rollback unchanged case");
+
+    // A changed numeric rating output should invalidate its tournament.
+    let mut changed_ratings = previous_ratings.clone();
+    changed_ratings[0].rating = 1510.0;
+    changed_ratings[0].adjustments.last_mut().unwrap().rating_after = 1510.0;
+    let mut changed_transaction = db_client
+        .begin_transaction()
+        .await
+        .expect("Failed to begin transaction");
+    db_client.snapshot_match_rating_adjustments().await;
+    db_client.save_results(&changed_ratings).await;
+    assert_eq!(
+        db_client.get_tournaments_with_changed_rating_adjustments().await,
+        vec![tournament_id]
+    );
+    changed_transaction
+        .rollback()
+        .await
+        .expect("Failed to rollback changed case");
+
+    // Adding a new player's match adjustment should also invalidate the tournament.
+    let mut added_ratings = previous_ratings.clone();
+    added_ratings.push(player_rating_with_match_adjustment(2, match_id, 1400.0, timestamp));
+    let mut added_transaction = db_client
+        .begin_transaction()
+        .await
+        .expect("Failed to begin transaction");
+    db_client.snapshot_match_rating_adjustments().await;
+    db_client.save_results(&added_ratings).await;
+    assert_eq!(
+        db_client.get_tournaments_with_changed_rating_adjustments().await,
+        vec![tournament_id]
+    );
+    added_transaction
+        .rollback()
+        .await
+        .expect("Failed to rollback added case");
+
+    // Removing an existing match adjustment should invalidate the tournament.
+    let mut removed_transaction = db_client
+        .begin_transaction()
+        .await
+        .expect("Failed to begin transaction");
+    db_client.snapshot_match_rating_adjustments().await;
+    db_client
+        .client()
+        .execute("DELETE FROM rating_adjustments WHERE match_id = $1", &[&match_id])
+        .await
+        .expect("Failed to remove match adjustment");
+    assert_eq!(
+        db_client.get_tournaments_with_changed_rating_adjustments().await,
+        vec![tournament_id]
+    );
+    removed_transaction
+        .rollback()
+        .await
+        .expect("Failed to rollback removed case");
+
+    // Initial and decay adjustments are not inputs to per-match tournament statistics.
+    let mut non_match_transaction = db_client
+        .begin_transaction()
+        .await
+        .expect("Failed to begin transaction");
+    db_client.snapshot_match_rating_adjustments().await;
+    db_client
+        .client()
+        .execute(
+            "UPDATE rating_adjustments SET rating_after = rating_after + 10 WHERE match_id IS NULL",
+            &[]
+        )
+        .await
+        .expect("Failed to change non-match adjustment");
+    assert!(db_client
+        .get_tournaments_with_changed_rating_adjustments()
+        .await
+        .is_empty());
+    non_match_transaction
+        .rollback()
+        .await
+        .expect("Failed to rollback non-match case");
+
+    // Rejected tournaments are not eligible for downstream stats processing.
+    let mut rejected_transaction = db_client
+        .begin_transaction()
+        .await
+        .expect("Failed to begin transaction");
+    db_client.snapshot_match_rating_adjustments().await;
+    db_client
+        .client()
+        .execute(
+            "UPDATE rating_adjustments SET rating_after = rating_after + 10 WHERE match_id = $1",
+            &[&match_id]
+        )
+        .await
+        .expect("Failed to change match adjustment");
+    db_client
+        .client()
+        .execute(
+            "UPDATE tournaments SET verification_status = 3 WHERE id = $1",
+            &[&tournament_id]
+        )
+        .await
+        .expect("Failed to reject tournament");
+    assert!(db_client
+        .get_tournaments_with_changed_rating_adjustments()
+        .await
+        .is_empty());
+    rejected_transaction
+        .rollback()
+        .await
+        .expect("Failed to rollback rejected case");
+}
+
+fn player_rating_with_match_adjustment(
+    player_id: i32,
+    match_id: i32,
+    rating_after: f64,
+    timestamp: DateTime<FixedOffset>
+) -> PlayerRating {
+    PlayerRating {
+        id: 0,
+        player_id,
+        ruleset: Ruleset::Osu,
+        rating: rating_after,
+        volatility: 200.0,
+        percentile: 0.5,
+        global_rank: player_id * 100,
+        country_rank: player_id * 10,
+        adjustments: vec![
+            RatingAdjustment {
+                player_id,
+                adjustment_type: RatingAdjustmentType::Initial,
+                ruleset: Ruleset::Osu,
+                rating_before: 0.0,
+                volatility_before: 0.0,
+                rating_after: 1200.0,
+                volatility_after: 400.0,
+                timestamp: timestamp - Duration::seconds(1),
+                match_id: None
+            },
+            RatingAdjustment {
+                player_id,
+                adjustment_type: RatingAdjustmentType::Match,
+                ruleset: Ruleset::Osu,
+                rating_before: 1200.0,
+                volatility_before: 400.0,
+                rating_after,
+                volatility_after: 200.0,
+                timestamp,
+                match_id: Some(match_id)
+            },
+        ]
+    }
 }
 
 #[tokio::test]

--- a/tests/database/schema.sql
+++ b/tests/database/schema.sql
@@ -56,7 +56,7 @@ CREATE UNIQUE INDEX ix_player_highest_ranks_player_id_ruleset ON public.player_h
 
 -- DROP TABLE player_osu_ruleset_data;
 
-CREATE TABLE player_osu_ruleset_data ( id int4 GENERATED ALWAYS AS IDENTITY( INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1 NO CYCLE) NOT NULL, ruleset int4 NOT NULL, pp float8 NOT NULL, global_rank int4 NOT NULL, earliest_global_rank int4 NULL, earliest_global_rank_date timestamptz NULL, player_id int4 NOT NULL, created timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL, updated timestamptz NULL, CONSTRAINT pk_player_osu_ruleset_data PRIMARY KEY (id), CONSTRAINT fk_player_osu_ruleset_data_players_player_id FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE);
+CREATE TABLE player_osu_ruleset_data ( id int4 GENERATED ALWAYS AS IDENTITY( INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1 NO CYCLE) NOT NULL, ruleset int4 NOT NULL, pp float8 NOT NULL, global_rank int4 NULL, earliest_global_rank int4 NULL, earliest_global_rank_date timestamptz NULL, player_id int4 NOT NULL, created timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL, updated timestamptz NULL, CONSTRAINT pk_player_osu_ruleset_data PRIMARY KEY (id), CONSTRAINT fk_player_osu_ruleset_data_players_player_id FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE);
 CREATE UNIQUE INDEX ix_player_osu_ruleset_data_player_id_ruleset ON public.player_osu_ruleset_data USING btree (player_id, ruleset);
 CREATE UNIQUE INDEX ix_player_osu_ruleset_data_player_id_ruleset_global_rank ON public.player_osu_ruleset_data USING btree (player_id, ruleset, global_rank);
 

--- a/tests/database/transaction_tests.rs
+++ b/tests/database/transaction_tests.rs
@@ -11,6 +11,27 @@ use crate::common::init_test_env;
 
 #[tokio::test]
 #[serial]
+async fn test_begin_transaction_uses_repeatable_read() {
+    init_test_env();
+    let test_db = TestDatabase::new().await.expect("Failed to create test database");
+    let client = DbClient::connect(&test_db.connection_string, false)
+        .await
+        .expect("Failed to connect");
+
+    let mut transaction = client.begin_transaction().await.expect("Failed to begin transaction");
+    let isolation_level: String = client
+        .client()
+        .query_one("SHOW transaction_isolation", &[])
+        .await
+        .expect("Failed to inspect transaction isolation")
+        .get(0);
+
+    assert_eq!(isolation_level, "repeatable read");
+    transaction.rollback().await.expect("Failed to rollback transaction");
+}
+
+#[tokio::test]
+#[serial]
 async fn test_transaction_rollback_on_processing_failure() {
     init_test_env();
     let test_db = TestDatabase::new().await.expect("Failed to create test database");


### PR DESCRIPTION
- Fixes a bug where matches could be processed out of chronological order when start and end times differed or the end time was null.
- Fixes a bug where player pagination could omit ruleset data, estimated to correct initial ratings for 6 players: 5 Mania 4K and 1 Taiko.
- Fixes a bug where a null current rank could discard a valid earliest known rank and incorrectly use the fallback initial rating.
- Fixes a bug where a recomputation could read inconsistent database state if data changed while processing.
  - In practice this is a non-issue because of our data freeze process in otr-web, but it's still something worth addressing.
- Fixes a bug where tournament statistics were not refreshed when recalculated rating adjustments changed.
- Fixes a bug where global and country highest ranks were not updated independently and unknown rank 0 could be treated as a valid peak.