### PR TITLE
Fix tie placement calculation

### DIFF
--- a/src/database/db.rs
+++ b/src/database/db.rs
@@ -911,8 +911,10 @@ impl DbClient {
     }
 
     /// Calculate and update placements for all game scores
-    /// Verified scores get placement based on score ranking (1=highest)
-    /// Non-verified scores get placement=0
+    /// Verified scores get placement based on score ranking (1=highest);
+    /// tied scores share the same placement and the following placement is
+    /// skipped (e.g. 1, 1, 3). This tells the model a tie exists for first.
+    /// Non-verified scores receive a fallback placement of 0 but are not considered.
     pub async fn calculate_and_update_game_score_placements(&self) {
         info!("Calculating game score placements...");
         let timer = Instant::now();
@@ -963,12 +965,10 @@ impl DbClient {
                         id,
                         CASE
                             WHEN verification_status = 4 THEN
-                                SUM(CASE WHEN verification_status = 4 THEN 1 ELSE 0 END)
-                                    OVER (
-                                        PARTITION BY game_id
-                                        ORDER BY score DESC, id
-                                        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-                                    )
+                                RANK() OVER (
+                                    PARTITION BY game_id, verification_status
+                                    ORDER BY score DESC
+                                )
                             ELSE 0
                         END AS new_placement
                     FROM game_scores

--- a/src/model/decay.rs
+++ b/src/model/decay.rs
@@ -18,7 +18,7 @@ use crate::{
     model::structures::rating_adjustment_type::RatingAdjustmentType::{Decay, VolatilityDecay}
 };
 use chrono::{DateTime, Duration, FixedOffset};
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 /// Unified decay system that combines rating decay (for inactive players)
 /// and volatility decay (for all players) into single Wednesday 12:00 UTC adjustments.
@@ -113,8 +113,9 @@ impl UnifiedDecaySystem {
             current += Duration::weeks(1);
         }
 
-        // Filter out Wednesdays before the decay start date to prevent unfair decay
-        // for players active in community tournaments before accessible data begins (~May 2018)
+        // Filter out Wednesdays before the decay start date (2019-01-01) to prevent
+        // unfair decay for players active in community tournaments before tournament
+        // data saving was implemented.
         let start = decay_start_date();
         timestamps.retain(|t| *t >= start);
 
@@ -198,6 +199,18 @@ impl UnifiedDecaySystem {
         } else {
             current_rating
         };
+
+        // Decay must never raise a rating or shrink volatility. Neither is
+        // reachable through the logic above; clamp and warn so a future
+        // regression surfaces in logs instead of silently boosting players.
+        let (new_rating, new_volatility) = Self::enforce_decay_invariants(
+            player_rating.player_id,
+            wednesday,
+            current_rating,
+            new_rating,
+            current_volatility,
+            new_volatility
+        );
 
         // Skip if no actual changes
         if (new_rating - current_rating).abs() < f64::EPSILON
@@ -292,6 +305,45 @@ impl UnifiedDecaySystem {
     /// Calculates new rating after decay, ensuring it doesn't fall below the decay floor.
     fn calculate_decay_rating(current_rating: f64, decay_floor: f64) -> f64 {
         (current_rating - DECAY_RATE).max(decay_floor)
+    }
+
+    /// Guards the decay invariants: a decay adjustment may never increase a
+    /// player's rating or decrease their volatility. Returns clamped values,
+    /// logging a warning if an unexpected decay attempt was blocked.
+    fn enforce_decay_invariants(
+        player_id: i32,
+        wednesday: DateTime<FixedOffset>,
+        current_rating: f64,
+        new_rating: f64,
+        current_volatility: f64,
+        new_volatility: f64
+    ) -> (f64, f64) {
+        let mut rating = new_rating;
+        let mut volatility = new_volatility;
+
+        if rating > current_rating {
+            warn!(
+                player_id,
+                timestamp = %wednesday,
+                rating_before = current_rating,
+                attempted_rating_after = rating,
+                "Unexpected decay attempt would have increased rating; clamping to previous rating"
+            );
+            rating = current_rating;
+        }
+
+        if volatility < current_volatility {
+            warn!(
+                player_id,
+                timestamp = %wednesday,
+                volatility_before = current_volatility,
+                attempted_volatility_after = volatility,
+                "Unexpected decay attempt would have decreased volatility; clamping to previous volatility"
+            );
+            volatility = current_volatility;
+        }
+
+        (rating, volatility)
     }
 }
 
@@ -1165,6 +1217,72 @@ mod tests {
         assert_eq!(volatility_count, expected_active);
         assert_eq!(decay_count, expected_inactive);
         assert_eq!(total_count, all_wednesdays.len());
+    }
+
+    #[test]
+    fn test_enforce_decay_invariants_blocks_rating_increase() {
+        let wednesday = Utc.with_ymd_and_hms(2024, 1, 3, 12, 0, 0).unwrap().fixed_offset();
+
+        // A rating increase must be clamped back to the previous rating
+        let (rating, volatility) =
+            UnifiedDecaySystem::enforce_decay_invariants(1, wednesday, 900.0, 1000.0, 200.0, 210.0);
+        assert_abs_diff_eq!(rating, 900.0);
+        assert_abs_diff_eq!(volatility, 210.0);
+
+        // A volatility decrease must be clamped back to the previous volatility
+        let (rating, volatility) =
+            UnifiedDecaySystem::enforce_decay_invariants(1, wednesday, 1500.0, 1497.0, 200.0, 150.0);
+        assert_abs_diff_eq!(rating, 1497.0);
+        assert_abs_diff_eq!(volatility, 200.0);
+
+        // Valid decay values pass through untouched
+        let (rating, volatility) =
+            UnifiedDecaySystem::enforce_decay_invariants(1, wednesday, 1500.0, 1497.0, 200.0, 210.0);
+        assert_abs_diff_eq!(rating, 1497.0);
+        assert_abs_diff_eq!(volatility, 210.0);
+    }
+
+    #[test]
+    fn test_inactive_player_below_floor_never_boosted() {
+        // A player whose current rating sits below their decay floor must never
+        // have decay raise them toward the floor
+        let mut system = UnifiedDecaySystem::new();
+
+        let last_played = Utc.with_ymd_and_hms(2023, 1, 1, 12, 0, 0).unwrap().fixed_offset();
+        let mut ratings = vec![generate_player_rating(
+            1,
+            Ruleset::Osu,
+            900.0, // Below DECAY_MINIMUM (1000), therefore below any possible floor
+            200.0,
+            2,
+            Some(last_played),
+            Some(last_played)
+        )];
+
+        let baseline = Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap().fixed_offset();
+        apply_decay_up_to(&mut system, &mut ratings, baseline);
+
+        let many_weeks_later = Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap().fixed_offset();
+        apply_decay_up_to(&mut system, &mut ratings, many_weeks_later);
+
+        for adj in ratings[0]
+            .adjustments
+            .iter()
+            .filter(|a| a.adjustment_type == Decay || a.adjustment_type == VolatilityDecay)
+        {
+            assert!(
+                adj.rating_after <= adj.rating_before + f64::EPSILON,
+                "Decay must never increase rating"
+            );
+            assert!(
+                adj.volatility_after >= adj.volatility_before - f64::EPSILON,
+                "Decay must never decrease volatility"
+            );
+        }
+        assert!(
+            ratings[0].rating <= 900.0 + f64::EPSILON,
+            "Rating must not be boosted toward the floor"
+        );
     }
 
     // --- Decay window start date tests ---

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -197,7 +197,10 @@ impl OtrModel {
     fn apply_tie_for_last_scores(&self, match_: &mut Match, ids: &[i32]) {
         for game in &mut match_.games {
             let Some(worst_placement) = game.scores.iter().map(|f| f.placement).max() else {
-                warn!(game_id = game.id, "Game has no scores, skipping apply_tie_for_last_scores");
+                warn!(
+                    game_id = game.id,
+                    "Game has no scores, skipping apply_tie_for_last_scores"
+                );
                 continue;
             };
             let tie_for_last_placement = worst_placement + 1;

--- a/src/model/otr_model.rs
+++ b/src/model/otr_model.rs
@@ -196,7 +196,10 @@ impl OtrModel {
     /// - Score of 0
     fn apply_tie_for_last_scores(&self, match_: &mut Match, ids: &[i32]) {
         for game in &mut match_.games {
-            let worst_placement = game.scores.iter().map(|f| f.placement).max().unwrap();
+            let Some(worst_placement) = game.scores.iter().map(|f| f.placement).max() else {
+                warn!(game_id = game.id, "Game has no scores, skipping apply_tie_for_last_scores");
+                continue;
+            };
             let tie_for_last_placement = worst_placement + 1;
 
             let missing_players = ids
@@ -547,6 +550,56 @@ mod tests {
 
         assert!(result_2.mu > result_1.mu);
         assert!(result_1.mu > result_3.mu);
+    }
+
+    #[test]
+    fn test_rate_tied_scores_share_placement() {
+        // Two players tie for 1st (identical scores share a placement), a third is 3rd.
+        // The tied players start identical, so they must receive identical results.
+        let player_ratings = vec![
+            generate_player_rating(1, Osu, 1000.0, 100.0, 1, None, None),
+            generate_player_rating(2, Osu, 1000.0, 100.0, 1, None, None),
+            generate_player_rating(3, Osu, 1000.0, 100.0, 1, None, None),
+        ];
+
+        let countries = generate_country_mapping_player_ratings(player_ratings.as_slice(), "US");
+        let model = OtrModel::new(player_ratings.as_slice(), &countries);
+
+        let tied_placements = vec![
+            generate_placement(1, 1),
+            generate_placement(2, 1),
+            generate_placement(3, 3),
+        ];
+        let tied_result = model.rate(&generate_game(1, &tied_placements), &Osu);
+
+        let tied_1 = tied_result.get(&1).unwrap();
+        let tied_2 = tied_result.get(&2).unwrap();
+        let tied_3 = tied_result.get(&3).unwrap();
+
+        // Tied players are treated identically and both beat the 3rd-place player
+        assert_eq!(tied_1.mu, tied_2.mu, "Tied players must receive the same rating");
+        assert_eq!(
+            tied_1.sigma, tied_2.sigma,
+            "Tied players must receive the same volatility"
+        );
+        assert!(tied_1.mu > tied_3.mu);
+
+        // A tie must not be scored like a sequential 1-2-3 finish
+        let sequential_placements = vec![
+            generate_placement(1, 1),
+            generate_placement(2, 2),
+            generate_placement(3, 3),
+        ];
+        let sequential_result = model.rate(&generate_game(1, &sequential_placements), &Osu);
+        assert!(
+            tied_result.get(&1).unwrap().mu < sequential_result.get(&1).unwrap().mu,
+            "Tying for 1st must award less than winning 1st outright"
+        );
+        assert_ne!(
+            tied_result.get(&2).unwrap().sigma,
+            sequential_result.get(&2).unwrap().sigma,
+            "A tie for 1st must produce a different result than finishing 2nd"
+        );
     }
 
     #[test]

--- a/src/model/rating_utils.rs
+++ b/src/model/rating_utils.rs
@@ -106,13 +106,14 @@ fn initial_rating(player: &Player, ruleset: &Ruleset) -> f64 {
                     }
                 }
 
-                // Fallback: use global_rank from the respective ruleset
-                if let Some(global_rank) = data
+                // Fallback: use the respective ruleset's own rank,
+                // preferring the earliest-known rank per the closest-known-rank rule
+                if let Some(rank) = data
                     .iter()
                     .find(|rd| rd.ruleset == *ruleset)
-                    .and_then(|ruleset_data| ruleset_data.global_rank)
+                    .and_then(|ruleset_data| ruleset_data.earliest_global_rank.or(ruleset_data.global_rank))
                 {
-                    return mu_from_rank(global_rank, *ruleset);
+                    return mu_from_rank(rank, *ruleset);
                 }
 
                 // If no data found, use fallback rating
@@ -354,7 +355,8 @@ mod tests {
         assert_eq!(mania4k_rating, expected_rating_from_mania_other);
         assert_eq!(mania7k_rating, expected_rating_from_mania_other_7k);
 
-        // Test case 2: Player without ManiaOther earliest_global_rank - should use respective ruleset global_rank
+        // Test case 2: Player without ManiaOther earliest_global_rank - should use the
+        // respective ruleset's own rank, preferring the earliest-known rank
         let player_without_mania_other_earliest = Player {
             id: 2,
             username: Some("TestPlayer2".to_string()),
@@ -368,8 +370,8 @@ mod tests {
 
         let mania4k_rating_fallback = super::initial_rating(&player_without_mania_other_earliest, &Mania4k);
         let mania7k_rating_fallback = super::initial_rating(&player_without_mania_other_earliest, &Mania7k);
-        let expected_mania4k_fallback = mu_from_rank(2000, Mania4k); // Using Mania4k global_rank
-        let expected_mania7k_fallback = mu_from_rank(3000, Mania7k); // Using Mania7k global_rank
+        let expected_mania4k_fallback = mu_from_rank(1500, Mania4k); // Using Mania4k earliest_global_rank
+        let expected_mania7k_fallback = mu_from_rank(2500, Mania7k); // Using Mania7k earliest_global_rank
 
         assert_eq!(mania4k_rating_fallback, expected_mania4k_fallback);
         assert_eq!(mania7k_rating_fallback, expected_mania7k_fallback);

--- a/tests/database/db_tests.rs
+++ b/tests/database/db_tests.rs
@@ -591,6 +591,28 @@ async fn test_calculate_and_update_game_score_placements() {
         )
         .await
         .expect("Failed to mark a score as unverified");
+    // Force a tied score pair within one game to exercise shared placements
+    admin_client
+        .execute(
+            "
+            UPDATE game_scores
+            SET score = tied.max_score
+            FROM (
+                SELECT game_id, MAX(score) AS max_score
+                FROM game_scores
+                WHERE verification_status = 4
+                GROUP BY game_id
+                HAVING COUNT(*) >= 2
+                ORDER BY game_id
+                LIMIT 1
+            ) AS tied
+            WHERE game_scores.game_id = tied.game_id
+                AND game_scores.verification_status = 4
+        ",
+            &[]
+        )
+        .await
+        .expect("Failed to create tied scores");
 
     let db_client = DbClient::connect(&test_db.connection_string, false)
         .await
@@ -610,32 +632,55 @@ async fn test_calculate_and_update_game_score_placements() {
         .await
         .expect("Failed to fetch placements");
 
-    let mut current_game: Option<i32> = None;
-    let mut expected_placement = 1;
+    // Collect (game_id, score, verification_status, placement) tuples
+    let scores: Vec<(i32, i32, i32, i32)> = rows
+        .iter()
+        .map(|row| {
+            (
+                row.get("game_id"),
+                row.get("score"),
+                row.get("verification_status"),
+                row.get("placement")
+            )
+        })
+        .collect();
 
-    for row in rows {
-        let game_id: i32 = row.get("game_id");
-        let verification_status: i32 = row.get("verification_status");
-        let placement: i32 = row.get("placement");
-
-        if current_game != Some(game_id) {
-            current_game = Some(game_id);
-            expected_placement = 1;
-        }
-
-        if verification_status == 4 {
-            assert_eq!(
-                placement, expected_placement,
-                "Verified score in game {} should have sequential placement",
-                game_id
-            );
-            expected_placement += 1;
-        } else {
+    let mut saw_shared_placement = false;
+    for &(game_id, score, verification_status, placement) in &scores {
+        if verification_status != 4 {
             assert_eq!(
                 placement, 0,
                 "Unverified score in game {} should have placement 0",
                 game_id
             );
+            continue;
+        }
+
+        // Tie-aware rank: 1 + number of verified scores in the same game
+        // with a strictly higher score. Tied scores share a placement and
+        // the following placement is skipped.
+        let expected_placement = 1 + scores
+            .iter()
+            .filter(|&&(g, s, vs, _)| g == game_id && vs == 4 && s > score)
+            .count() as i32;
+
+        assert_eq!(
+            placement, expected_placement,
+            "Verified score in game {} should have tie-aware placement",
+            game_id
+        );
+
+        let sharing = scores
+            .iter()
+            .filter(|&&(g, _, vs, p)| g == game_id && vs == 4 && p == placement)
+            .count();
+        if sharing > 1 {
+            saw_shared_placement = true;
         }
     }
+
+    assert!(
+        saw_shared_placement,
+        "Fixture should include at least one tied pair sharing a placement"
+    );
 }


### PR DESCRIPTION
This PR:

- Fixes a bug with how ties are handled, described below.
- Adds a safeguard that prevents decay from applying in the inverse direction.

## Ties

The processor previously assigned every player in a game a unique
placement, even when two or more players had identical scores. Ties
were broken arbitrarily by database row order, meaning the "winner" of a tied
score was decided by which score happened to be stored first. The fix makes
tied scores share the same placement. 2,601 games are directly impacted.